### PR TITLE
Fix typo and don't translate app name

### DIFF
--- a/primitiveFTPd/res/values/strings.xml
+++ b/primitiveFTPd/res/values/strings.xml
@@ -1,8 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
 
-    <string name="app_name">primiti
-\nve ftpd</string>
+    <string name="app_name" translatable="false">primitive ftpd</string>
     <string name="ifacesLabel">Network Interface</string>
     <string name="ipAddrLabel">IP Address</string>
     <string name="ifacesError">Error: </string>


### PR DESCRIPTION
FYI you should have a "source of truth" for strings (eg. say English) and only modify this here in code and push for the others to translate in their locales.

Also, have the app easily found by having the same name in all languages.