### PR TITLE
Add compatibility for storage on Android 10:

### DIFF
--- a/primitiveFTPd/AndroidManifest.xml
+++ b/primitiveFTPd/AndroidManifest.xml
@@ -23,7 +23,8 @@
         android:roundIcon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:allowBackup="false"
-        android:banner="@drawable/ic_launcher">
+        android:banner="@drawable/ic_launcher"
+        android:requestLegacyExternalStorage="true">
 
         <receiver android:enabled="true" android:name=".BootUpReceiver"
                 android:permission="android.permission.RECEIVE_BOOT_COMPLETED">


### PR DESCRIPTION
- Temporarily opt-out of scoped storage so we can use the plain old filesystem and the authorized_keys file.

This is just a quick fix for Android 10 devices. Would be nice to see a new release soon, so I can use this app for my backup again.