### PR TITLE
Changes on Quick Settings tile behaviour

### DIFF
--- a/primitiveFTPd/AndroidManifest.xml
+++ b/primitiveFTPd/AndroidManifest.xml
@@ -85,6 +85,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <action android:name="android.intent.action.VIEW" /><!-- to avoid missing app link warning -->
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES"/>
+            </intent-filter>
             <meta-data android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>

--- a/primitiveFTPd/res/values/strings.xml
+++ b/primitiveFTPd/res/values/strings.xml
@@ -89,7 +89,9 @@
     <string name="prefSummaryLoggingV2">Log serves analyzing of errors. If the app does not work properly on your device you can send a log to developers. May require to restart the app. Text Logs are stored in %s.</string>
     <string name="prefAllowedIpsPattern">Allowed IPs pattern</string>
     <string name="prefSummaryAllowedIpsPattern">Pattern of allowed IP Addresses. Just one Wildcard (*) may be used, as last character only.</string>
-
+    <string name="prefTitleQuickSettingsRequiresUnlock">Quick Settings Tile unlock requirement</string>
+    <string name="prefSummaryQuickSettingsRequiresUnlock">Clicking the quick settings tile requires the device to be unlocked to start/stop the server(s). When enabled, will prompted to unlock the device if it's locked.</string>
+  
     <string name="licence">Licence</string>
     <string name="reset">Reset</string>
 

--- a/primitiveFTPd/res/xml/preferences.xml
+++ b/primitiveFTPd/res/xml/preferences.xml
@@ -120,7 +120,7 @@
     <SwitchPreference
 			android:name="quickSettingsRequiresUnlock"
 			android:key="quickSettingsRequiresUnlockPref"
-			android:defaultValue="false"
+			android:defaultValue="true"
 			android:title="@string/prefTitleQuickSettingsRequiresUnlock"
 			android:summary="@string/prefSummaryQuickSettingsRequiresUnlock"
 			/>

--- a/primitiveFTPd/res/xml/preferences.xml
+++ b/primitiveFTPd/res/xml/preferences.xml
@@ -117,6 +117,13 @@
 			android:title="@string/prefTitleShowStartStopNotification"
 			android:summary="@string/prefSummaryShowStartStopNotification"
 			/>
+    <SwitchPreference
+			android:name="quickSettingsRequiresUnlock"
+			android:key="quickSettingsRequiresUnlockPref"
+			android:defaultValue="false"
+			android:title="@string/prefTitleQuickSettingsRequiresUnlock"
+			android:summary="@string/prefSummaryQuickSettingsRequiresUnlock"
+			/>
 		<ListPreference
 			android:name="theme"
 			android:key="themePref"

--- a/primitiveFTPd/src/org/primftpd/prefs/LoadPrefsUtil.java
+++ b/primitiveFTPd/src/org/primftpd/prefs/LoadPrefsUtil.java
@@ -36,6 +36,7 @@ public class LoadPrefsUtil
 	public static final String PREF_KEY_STORAGE_TYPE = "storageTypePref";
 	public static final String PREF_KEY_SAF_URL = "safUrlPref";
 	public static final String PREF_KEY_ALLOWED_IPS_PATTERN = "allowedIpsPatternPref";
+	public static final String PREF_QUICK_SETTINGS_REQUIRES_UNLOCK = "quickSettingsRequiresUnlockPref";
 
 	public static final int PORT_DEFAULT_VAL = 12345;
 	static final String PORT_DEFAULT_VAL_STR = String.valueOf(PORT_DEFAULT_VAL);
@@ -271,6 +272,12 @@ public class LoadPrefsUtil
 		return true;
 	}
 
+	public static Boolean quickSettingsRequiresUnlock(SharedPreferences prefs) {
+		return prefs.getBoolean(
+			LoadPrefsUtil.PREF_QUICK_SETTINGS_REQUIRES_UNLOCK,
+			Boolean.FALSE);
+	}
+
 	public static PrefsBean loadPrefs(Logger logger, SharedPreferences prefs) {
 		boolean anonymousLogin = anonymousLogin(prefs);
 		logger.debug("got anonymousLogin: {}", Boolean.valueOf(anonymousLogin));
@@ -323,6 +330,9 @@ public class LoadPrefsUtil
 		String allowedIpsPattern = allowedIpsPattern(prefs);
 		logger.debug("got allowedIpsPattern: {}", allowedIpsPattern);
 
+		boolean quickSettingsRequiresUnlock = quickSettingsRequiresUnlock(prefs);
+		logger.debug("got quickSettingsRequiresUnlock: {}", Boolean.valueOf(quickSettingsRequiresUnlock));
+
 		// create prefsBean
 		return new PrefsBean(
 				userName,
@@ -341,6 +351,7 @@ public class LoadPrefsUtil
 				showConnectionInfo,
 				storageType,
 				safUrl,
-				allowedIpsPattern);
+				allowedIpsPattern,
+				quickSettingsRequiresUnlock);
 	}
 }

--- a/primitiveFTPd/src/org/primftpd/prefs/LoadPrefsUtil.java
+++ b/primitiveFTPd/src/org/primftpd/prefs/LoadPrefsUtil.java
@@ -275,7 +275,7 @@ public class LoadPrefsUtil
 	public static Boolean quickSettingsRequiresUnlock(SharedPreferences prefs) {
 		return prefs.getBoolean(
 			LoadPrefsUtil.PREF_QUICK_SETTINGS_REQUIRES_UNLOCK,
-			Boolean.FALSE);
+			Boolean.TRUE);
 	}
 
 	public static PrefsBean loadPrefs(Logger logger, SharedPreferences prefs) {
@@ -330,9 +330,6 @@ public class LoadPrefsUtil
 		String allowedIpsPattern = allowedIpsPattern(prefs);
 		logger.debug("got allowedIpsPattern: {}", allowedIpsPattern);
 
-		boolean quickSettingsRequiresUnlock = quickSettingsRequiresUnlock(prefs);
-		logger.debug("got quickSettingsRequiresUnlock: {}", Boolean.valueOf(quickSettingsRequiresUnlock));
-
 		// create prefsBean
 		return new PrefsBean(
 				userName,
@@ -351,7 +348,6 @@ public class LoadPrefsUtil
 				showConnectionInfo,
 				storageType,
 				safUrl,
-				allowedIpsPattern,
-				quickSettingsRequiresUnlock);
+				allowedIpsPattern);
 	}
 }

--- a/primitiveFTPd/src/org/primftpd/prefs/PrefsBean.java
+++ b/primitiveFTPd/src/org/primftpd/prefs/PrefsBean.java
@@ -26,6 +26,7 @@ public class PrefsBean implements Serializable
 	private final StorageType storageType;
 	private final String safUrl;
 	private final String allowedIpsPattern;
+	private final boolean quickSettingsRequiresUnlock;
 
 	public PrefsBean(
 		String userName,
@@ -44,7 +45,8 @@ public class PrefsBean implements Serializable
 		boolean showConnectionInfoInNotification,
 		StorageType storageType,
 		String safUrl,
-		String allowedIpsPattern)
+		String allowedIpsPattern,
+		boolean quickSettingsRequiresUnlock)
 	{
 		super();
 		this.userName = userName;
@@ -66,6 +68,7 @@ public class PrefsBean implements Serializable
 		this.storageType = storageType;
 		this.safUrl = safUrl;
 		this.allowedIpsPattern = allowedIpsPattern;
+		this.quickSettingsRequiresUnlock = quickSettingsRequiresUnlock;
 	}
 
 	public String getUserName() {
@@ -143,5 +146,9 @@ public class PrefsBean implements Serializable
 
 	public String getAllowedIpsPattern() {
 		return allowedIpsPattern;
+	}
+
+	public boolean quickSettingsRequiresUnlock() {
+		return quickSettingsRequiresUnlock;
 	}
 }

--- a/primitiveFTPd/src/org/primftpd/prefs/PrefsBean.java
+++ b/primitiveFTPd/src/org/primftpd/prefs/PrefsBean.java
@@ -26,7 +26,6 @@ public class PrefsBean implements Serializable
 	private final StorageType storageType;
 	private final String safUrl;
 	private final String allowedIpsPattern;
-	private final boolean quickSettingsRequiresUnlock;
 
 	public PrefsBean(
 		String userName,
@@ -45,8 +44,7 @@ public class PrefsBean implements Serializable
 		boolean showConnectionInfoInNotification,
 		StorageType storageType,
 		String safUrl,
-		String allowedIpsPattern,
-		boolean quickSettingsRequiresUnlock)
+		String allowedIpsPattern)
 	{
 		super();
 		this.userName = userName;
@@ -68,7 +66,6 @@ public class PrefsBean implements Serializable
 		this.storageType = storageType;
 		this.safUrl = safUrl;
 		this.allowedIpsPattern = allowedIpsPattern;
-		this.quickSettingsRequiresUnlock = quickSettingsRequiresUnlock;
 	}
 
 	public String getUserName() {
@@ -146,9 +143,5 @@ public class PrefsBean implements Serializable
 
 	public String getAllowedIpsPattern() {
 		return allowedIpsPattern;
-	}
-
-	public boolean quickSettingsRequiresUnlock() {
-		return quickSettingsRequiresUnlock;
 	}
 }

--- a/primitiveFTPd/src/org/primftpd/services/QuickSettingsService.java
+++ b/primitiveFTPd/src/org/primftpd/services/QuickSettingsService.java
@@ -29,6 +29,30 @@ public class QuickSettingsService extends TileService {
     public void onClick() {
         logger.debug("onClick");
         super.onClick();
+        boolean unlockedOnly = false; // Grab value from somewhere
+
+        if(unlockedOnly) {
+            // Check whether the device is locked or not.
+            if(isLocked()){
+                unlockAndRun(
+                    new Runnable(){
+                        @Override
+                        public void run() {
+                            toggle();
+                        }
+                    }
+                );
+            } else {
+                toggle();
+            }
+        } else {
+            toggle();
+        }
+
+        updateTile();
+    }
+
+    private void toggle(){
         boolean isActive = isActive();
         if(isActive) {
             // Stop service if it is already running.
@@ -37,7 +61,6 @@ public class QuickSettingsService extends TileService {
             // Start FTP service.
             ServicesStartStopUtil.startServers(this);
         }
-        updateTile();
     }
 
     /**

--- a/primitiveFTPd/src/org/primftpd/services/QuickSettingsService.java
+++ b/primitiveFTPd/src/org/primftpd/services/QuickSettingsService.java
@@ -2,10 +2,12 @@ package org.primftpd.services;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.content.Context;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
 
 import org.primftpd.R;
+import org.primftpd.prefs.LoadPrefsUtil;
 import org.primftpd.util.ServersRunningBean;
 import org.primftpd.util.ServicesStartStopUtil;
 import org.slf4j.Logger;
@@ -29,7 +31,8 @@ public class QuickSettingsService extends TileService {
     public void onClick() {
         logger.debug("onClick");
         super.onClick();
-        boolean unlockedOnly = false; // Grab value from somewhere
+        SharedPreferences prefs = LoadPrefsUtil.getPrefs(getBaseContext());
+        boolean unlockedOnly = LoadPrefsUtil.quickSettingsRequiresUnlock(prefs);
 
         if(unlockedOnly) {
             // Check whether the device is locked or not.

--- a/primitiveFTPd/src/org/primftpd/services/QuickSettingsService.java
+++ b/primitiveFTPd/src/org/primftpd/services/QuickSettingsService.java
@@ -34,7 +34,7 @@ public class QuickSettingsService extends TileService {
         SharedPreferences prefs = LoadPrefsUtil.getPrefs(getBaseContext());
         boolean unlockedOnly = LoadPrefsUtil.quickSettingsRequiresUnlock(prefs);
 
-        if(unlockedOnly) {
+        if(unlockedOnly && isLocked()) {
             // Check whether the device is locked or not.
             if(isLocked()){
                 unlockAndRun(
@@ -45,8 +45,6 @@ public class QuickSettingsService extends TileService {
                         }
                     }
                 );
-            } else {
-                toggle();
             }
         } else {
             toggle();


### PR DESCRIPTION
- [X] Made clicking the quick settings tile check whether the device is locked or not, if the users chose that. #208 
- [x] Add a preference for that.
- [x] Get the preference state when executing.
- [X] Long-Pressing the tile will launch the main activity.