### PR TITLE
Fix ambiguity in prefSummaryIdleTimeout/V2

### DIFF
--- a/primitiveFTPd/res/values-ar/strings.xml
+++ b/primitiveFTPd/res/values-ar/strings.xml
@@ -80,8 +80,8 @@
     <string name="prefTitleFtpPassivePorts">منافذ FTP الخاملة</string>
     <string name="prefSummaryFtpPassivePorts">المنافذ المستخدمة للاتّصالات الخاملة لنقل البيانات عن طريق FTP. يمكن أن يكون منفذاً وحيداً، أو قائمة أو نطاق من المنافذ. مثل: 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">مهلة عدم نشاط الخادم</string>
-    <string name="prefSummaryIdleTimeout">سينهي الخادم العلاقات غير النشطة بعد هذه المهلة (FTP فقط).</string>
-    <string name="prefSummaryIdleTimeoutV2">سينهي الخادم العلاقات غير النشطة بعد هذه المهلة. ضع 0 للإلغاء.</string>
+    <string name="prefSummaryIdleTimeout">سينهي الخادم الاتصالات الخاملة بعد هذا الوقت بالثواني. اضبط على 0 للتعطيل.</string>
+    <string name="prefSummaryIdleTimeoutV2">سينهي الخادم الاتصالات الخاملة بعد هذا الوقت بالثواني. اضبط على 0 للتعطيل.</string>
     <string name="prefTheme">السمة</string>
     <string name="prefSummaryTheme">تغيير السمة سيتطلّب إعادة تشغيل التطبيق.</string>
     <string name="prefTitleLogging">السجل</string>

--- a/primitiveFTPd/res/values-de/strings.xml
+++ b/primitiveFTPd/res/values-de/strings.xml
@@ -74,8 +74,8 @@
     <string name="prefTitleFtpPassivePorts">FTP Passive Ports</string>
     <string name="prefSummaryFtpPassivePorts">Ports für FTP Passive-Daten-Verbindung. Kann ein einzelner Port, eine Liste oder Bereich von Ports sein. Z.B. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Server Idle-Timeout</string>
-    <string name="prefSummaryIdleTimeout">Server wird ungenutzte Verbindungen nach dieser Zeit beenden (nur FTP)</string>
-    <string name="prefSummaryIdleTimeoutV2">Server wird ungenutzte Verbindungen nach dieser Zeit beenden. Auf 0 setzen um abzuschalten.</string>
+    <string name="prefSummaryIdleTimeout">Server wird ungenutzte Verbindungen nach dieser Zeit in Sekunden beenden (nur FTP)</string>
+    <string name="prefSummaryIdleTimeoutV2">Server wird ungenutzte Verbindungen nach dieser Zeit in Sekunden beenden. Auf 0 setzen um abzuschalten.</string>
     <string name="prefSummaryTheme">Das Theme zu ändern kann einen Neustart der App erfordern.</string>
     <string name="prefTitleLogging">Log</string>
     <string name="prefSummaryLogging">Log dient der Analyse von Fehlern. Falls die App auf ihrem Gerät nicht richtig funktioniert können sie ein Log an die Entwickler senden. Es kann nötig sein die App neu zu starten.</string>

--- a/primitiveFTPd/res/values-el/strings.xml
+++ b/primitiveFTPd/res/values-el/strings.xml
@@ -66,6 +66,7 @@
     <string name="prefSummaryFtpPassivePorts">Πόρτες για παθητική σύνδεση δεδομένων FTP. Μπορεί να είναι μία πόρτα ή μία λίστα από πόρτες. Π.χ. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Χρονικό όριο Αδράνειας Εξυπηρετητή</string>
     <string name="prefSummaryIdleTimeout">Ο διακομιστής θα τερματίσει τις αδρανείς συνδέσεις μετά από αυτό το χρονικό διάστημα σε δευτερόλεπτα (μόνο FTP)</string>
+    <string name="prefSummaryIdleTimeoutV2">Ο διακομιστής θα τερματίσει τις αδρανείς συνδέσεις μετά από αυτό το χρονικό διάστημα σε δευτερόλεπτα. Ορίστε το 0 για απενεργοποίηση.</string>
     <string name="prefTheme">Θέμα</string>
     <string name="prefSummaryTheme">Η αλλαγή θέματος ίσως απαιτήσει την επανεκκίνηση της εφαρμογής.</string>
     <string name="prefTitleLogging">Αρχείο καταγραφής</string>

--- a/primitiveFTPd/res/values-el/strings.xml
+++ b/primitiveFTPd/res/values-el/strings.xml
@@ -65,7 +65,7 @@
     <string name="prefTitleFtpPassivePorts">Παθητικές Πόρτες FTP</string>
     <string name="prefSummaryFtpPassivePorts">Πόρτες για παθητική σύνδεση δεδομένων FTP. Μπορεί να είναι μία πόρτα ή μία λίστα από πόρτες. Π.χ. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Χρονικό όριο Αδράνειας Εξυπηρετητή</string>
-    <string name="prefSummaryIdleTimeout">Ο εξυπηρετητής θα τερματίζει ανενεργές συνδέσεις ύστερα από χρονικό όριο (Μόνο για FTP)</string>
+    <string name="prefSummaryIdleTimeout">Ο διακομιστής θα τερματίσει τις αδρανείς συνδέσεις μετά από αυτό το χρονικό διάστημα σε δευτερόλεπτα (μόνο FTP)</string>
     <string name="prefTheme">Θέμα</string>
     <string name="prefSummaryTheme">Η αλλαγή θέματος ίσως απαιτήσει την επανεκκίνηση της εφαρμογής.</string>
     <string name="prefTitleLogging">Αρχείο καταγραφής</string>

--- a/primitiveFTPd/res/values-es/strings.xml
+++ b/primitiveFTPd/res/values-es/strings.xml
@@ -93,7 +93,7 @@
     <string name="prefTitleFtpPassivePorts">Puertos pasivos FTP</string>
     <string name="prefSummaryFtpPassivePorts">Puertos para conexión FTP de datos pasivos. Puede ser un único puerto o una lista. Ej.: 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Tiempo de espera de inactividad del servidor</string>
-    <string name="prefSummaryIdleTimeout">El servidor terminará las conexiones inactivas después de este tiempo (sólo para FTP).</string>
+    <string name="prefSummaryIdleTimeout">El servidor terminará las conexiones inactivas después de este tiempo en segundos (sólo FTP)</string>
     <string name="isAnonymous">Inicio de sesión anónimo: %1$b</string>
     <string name="selectServerAction">Selecciona acción del servidor</string>
     <string name="isServerRunning">¿Está funcionando el servidor?</string>
@@ -113,7 +113,7 @@
     <string name="prefAllowedIpsPattern">Patrón de IPs permitidas</string>
     <string name="prefSummaryAllowedIpsPattern">Patrón de direcciones IP permitidas. Sólo puede usarse un único asterisco (*) y debe de estar al final.</string>
     <string name="prefSummaryShowIpv6InNotification">Muestra direcciones IPv6 en la notificación si esta está visible.</string>
-    <string name="prefSummaryIdleTimeoutV2">El servidor cerrará la sesión de los clientes inactivos una vez pase este tiempo. Ponlo a cero para desactivarlo.</string>
+    <string name="prefSummaryIdleTimeoutV2">El servidor terminará las conexiones inactivas después de este tiempo en segundos. Establecer a 0 para desactivar.</string>
     <string name="filepickerNeedValidFilename">Elige o introduce un nombre de archivo válido</string>
     <string name="passwordPresent">Con contraseña: %1$b</string>
     <string name="pubKeyAuth">Acceso con clave pública: %1$b</string>

--- a/primitiveFTPd/res/values-fr/strings.xml
+++ b/primitiveFTPd/res/values-fr/strings.xml
@@ -111,7 +111,7 @@
     <string name="prefAllowedIpsPattern">Modèle d\'adresses IP autorisés</string>
     <string name="prefSummaryLoggingV2">Les log servent à l\'analyse des erreurs. Si l\'application ne fonctionne pas correctement sur votre appareil, vous pouvez l\'envoyer aux développeurs. Peut nécessiter de redémarrer l\'application. Les logs textuel sont stocké dans %s.</string>
     <string name="prefSummaryLogging">Les log servent à l\'analyse des erreurs. Si l\'application ne fonctionne pas correctement sur votre appareil, vous pouvez l\'envoyer aux développeurs. Peut nécessiter de redémarrer l\'application.</string>
-    <string name="prefSummaryIdleTimeout">Le serveur terminera les connexions inactive après ce délais (FTP seulement)</string>
+    <string name="prefSummaryIdleTimeout">Le serveur terminera les connexions inactives après ce délais en secondes (FTP seulement).</string>
     <string name="prefSummaryFtpPassivePorts">Ports pour les connexions FTP passive. Peut être un seul port, une liste ou une plage de ports. Ex. 5678,5700-5710,5800,5900.</string>
     <string name="prefSummaryPubKeyAuth">Si activé, placer vos clés publique ssh2 dans %s. SFTP seulement.</string>
     <string name="quickShareCouldNotStartServer">Le serveur ne peut pas démarrer</string>
@@ -123,5 +123,5 @@
     <string name="downloadOrSaveUrlToFile">Télécharger ou sauvegarder l\'URL vers un fichier texte \?</string>
     <string name="prefSummaryQuickSettingsRequiresUnlock">"Le clic sur Vignettes rapides nécessite de déverrouillage de  équipement pour démarrer / arrêter le serveur. Quand actif, une demande de déverrouillage sera affiché si l\'équipement est verrouillé. "</string>
     <string name="prefTitleQuickSettingsRequiresUnlock">Déverrouillage nécessaire pour Vignettes Rapides</string>
-    <string name="prefSummaryIdleTimeoutV2">"Le serveur va couper les connexions inactifs passé ce délai. Régler sur 0 pour désactiver. "</string>
+    <string name="prefSummaryIdleTimeoutV2">Le serveur va couper les connexions inactives après ce délai en secondes. Réglez-le sur 0 pour désactiver.</string>
 </resources>

--- a/primitiveFTPd/res/values-hu/strings.xml
+++ b/primitiveFTPd/res/values-hu/strings.xml
@@ -51,6 +51,7 @@
     <string name="prefSummaryLoggingV2">"A napló a hibák elemzését szolgálja. Ha az alkalmazás nem működik megfelelően az eszközén, akkor a naplót elküldheti a fejlesztőknek. Szükség lehet az app újraindítására. A szövegnaplókat  %s tárolja."</string>
     <string name="prefSummaryLogging">A napló a hibák elemzését szolgálja. Ha az alkalmazás nem működik megfelelően az eszközén, a naplót elküldhei a fejlesztőknek. Ehhez az alkalmazás újraindítására is szükség lehet .</string>
     <string name="prefSummaryIdleTimeout">A kiszolgáló az üresjárati kapcsolatokat másodpercben megadott idő után megszakítja (csak FTP).</string>
+    <string name="prefSummaryIdleTimeoutV2">A kiszolgáló az üresjárati kapcsolatokat a másodpercben megadott idő után megszakítja. A letiltáshoz állítsa 0-ra.</string>
     <string name="prefTitleIdleTimeout">Szerver alap(értelmezett) időtúllépés</string>
     <string name="prefSummaryAnonymousLogin">Névtelen bejelentkezés engedélyezett-e a szerveren.</string>
     <string name="prefSummaryPubKeyAuth">Ha engedélyezve van, illessze be %s SSH2 nyilvános kulcsát. Csak SFTP-nél.</string>

--- a/primitiveFTPd/res/values-hu/strings.xml
+++ b/primitiveFTPd/res/values-hu/strings.xml
@@ -50,7 +50,7 @@
     <string name="prefAllowedIpsPattern">Engedélyezett IP-mód</string>
     <string name="prefSummaryLoggingV2">"A napló a hibák elemzését szolgálja. Ha az alkalmazás nem működik megfelelően az eszközén, akkor a naplót elküldheti a fejlesztőknek. Szükség lehet az app újraindítására. A szövegnaplókat  %s tárolja."</string>
     <string name="prefSummaryLogging">A napló a hibák elemzését szolgálja. Ha az alkalmazás nem működik megfelelően az eszközén, a naplót elküldhei a fejlesztőknek. Ehhez az alkalmazás újraindítására is szükség lehet .</string>
-    <string name="prefSummaryIdleTimeout">A kiszolgáló ezen idő után megszünteti a kapcsolatokat (csak FTP)</string>
+    <string name="prefSummaryIdleTimeout">A kiszolgáló az üresjárati kapcsolatokat másodpercben megadott idő után megszakítja (csak FTP).</string>
     <string name="prefTitleIdleTimeout">Szerver alap(értelmezett) időtúllépés</string>
     <string name="prefSummaryAnonymousLogin">Névtelen bejelentkezés engedélyezett-e a szerveren.</string>
     <string name="prefSummaryPubKeyAuth">Ha engedélyezve van, illessze be %s SSH2 nyilvános kulcsát. Csak SFTP-nél.</string>

--- a/primitiveFTPd/res/values-in/strings.xml
+++ b/primitiveFTPd/res/values-in/strings.xml
@@ -76,7 +76,7 @@
     <string name="prefTitleFtpPassivePorts">Porta FTP Pasif</string>
     <string name="prefSummaryFtpPassivePorts">Porta untuk koneksi data FTP Pasif. Boleh porta tunggal, beberapa atau rentang porta. Mis. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Batas Waktu Menganggur Server</string>
-    <string name="prefSummaryIdleTimeout">Server akan mematikan koneksi menganggur setelah waktu tersebut habis (hanya FTP)</string>
+    <string name="prefSummaryIdleTimeout">Server akan menghentikan koneksi yang tidak aktif setelah batas waktu ini dalam hitungan detik (hanya FTP).</string>
     <string name="prefTheme">Tema</string>
     <string name="prefSummaryTheme">Mengubah Tema mungkin membutuhkan aplikasi untuk dimulai ulang.</string>
     <string name="prefTitleLogging">Log</string>
@@ -148,7 +148,7 @@
     <string name="quickShareCouldNotStartServer">Server tidak bisa dimulai</string>
     <string name="quickShareServerStarted">Server telah mulai membagikan berkas tunggal</string>
     <string name="quickShare">Berbagi Cepat</string>
-    <string name="prefSummaryIdleTimeoutV2">Server akan mematikan koneksi mengangur setelah rentang waktu berikut. Atur ke 0 untuk menonaktifkan.</string>
+    <string name="prefSummaryIdleTimeoutV2">Server akan menghentikan koneksi yang tidak aktif setelah ini dalam hitungan detik. Setel ke 0 untuk menonaktifkan.</string>
     <string name="prefSummaryQuickSettingsRequiresUnlock">Klik pada ikon pengaturan cepat membutuhkan perangkat tidak terkunci untuk memulai/meyetop server. Ketika diaktifkan, akan meminta konfirmasi untuk membuka perangkat jika terkunci.</string>
     <string name="prefTitleQuickSettingsRequiresUnlock">Syarat buka kunci Ikon Pengaturan Cepat</string>
     <string name="statsReceivedPerSec">Diterima per detik</string>

--- a/primitiveFTPd/res/values-it/strings.xml
+++ b/primitiveFTPd/res/values-it/strings.xml
@@ -65,6 +65,7 @@
     <string name="prefSummaryFtpPassivePorts">Porte per la connessione FTP passiva. Può essere una singola porta, una lista o un intervallo di porte. Es. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Timeout inattività Server</string>
     <string name="prefSummaryIdleTimeout">Il server terminerà le connessioni inattive dopo questo tempo in secondi (solo FTP)</string>
+    <string name="prefSummaryIdleTimeoutV2">Il server terminerà le connessioni inattive dopo questo tempo in secondi. Impostare a 0 per disabilitare.</string>
     <string name="prefTheme">Tema</string>
     <string name="prefSummaryTheme">La modifica del Tema richiede il riavvio dell\'app.</string>
     <string name="prefTitleLogging">Log</string>

--- a/primitiveFTPd/res/values-it/strings.xml
+++ b/primitiveFTPd/res/values-it/strings.xml
@@ -64,7 +64,7 @@
     <string name="prefTitleFtpPassivePorts">Porte FTP Passivo</string>
     <string name="prefSummaryFtpPassivePorts">Porte per la connessione FTP passiva. Può essere una singola porta, una lista o un intervallo di porte. Es. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Timeout inattività Server</string>
-    <string name="prefSummaryIdleTimeout">Il Server terminerà le connessioni dopo questo periodo di inattività (Solo FTP)</string>
+    <string name="prefSummaryIdleTimeout">Il server terminerà le connessioni inattive dopo questo tempo in secondi (solo FTP)</string>
     <string name="prefTheme">Tema</string>
     <string name="prefSummaryTheme">La modifica del Tema richiede il riavvio dell\'app.</string>
     <string name="prefTitleLogging">Log</string>

--- a/primitiveFTPd/res/values-pl/strings.xml
+++ b/primitiveFTPd/res/values-pl/strings.xml
@@ -64,7 +64,7 @@
     <string name="prefTitleFtpPassivePorts">Pasywne porty FTP</string>
     <string name="prefSummaryFtpPassivePorts">Porty do pasywnego połączenia danych FTP. Może być pojedynczym portem, listą lub zakresem portów. Na przykład 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Limit czasu bezczynności serwera</string>
-    <string name="prefSummaryIdleTimeout">Serwer zakończy połączenia bezczynne po tym czasie (tylko FTP)</string>
+    <string name="prefSummaryIdleTimeout">Serwer będzie kończył bezczynne połączenia po upływie tego czasu w sekundach (tylko FTP)</string>
     <string name="prefTheme">Motyw</string>
     <string name="prefSummaryTheme">Zmiana motywu może wymagać ponownego uruchomienia aplikacji.</string>
     <string name="prefTitleLogging">Dziennik</string>
@@ -121,7 +121,7 @@
     <string name="quickShareCouldNotStartServer">Nie można uruchomić serwera</string>
     <string name="quickShareServerStarted">Serwer został uruchomiony udostępniając pojedynczy plik</string>
     <string name="quickShare">Szybkie udostępnianie</string>
-    <string name="prefSummaryIdleTimeoutV2">Po tym czasie serwer zakończy bezczynne połączenia. Ustaw na 0, aby wyłączyć.</string>
+    <string name="prefSummaryIdleTimeoutV2">Serwer będzie kończył bezczynne połączenia po upływie tego czasu w sekundach. Ustaw na 0 aby wyłączyć.</string>
     <string name="prefTitleQuickSettingsRequiresUnlock">Kafelek szybkich ustawień</string>
     <string name="prefSummaryQuickSettingsRequiresUnlock">Kliknięcie kafelka szybkich ustawień wymaga odblokowania urządzenia w celu uruchomienia/zatrzymania serwerów. Po włączeniu wyświetli monit o odblokowanie urządzenia, jeśli jest zablokowane.</string>
     <string name="statsReceivedPerSec">Odebrane w ciągu sekundy</string>

--- a/primitiveFTPd/res/values-pt-rBR/strings.xml
+++ b/primitiveFTPd/res/values-pt-rBR/strings.xml
@@ -80,8 +80,8 @@
     <string name="prefTitleFtpPassivePorts">Portas Passivas de FTP</string>
     <string name="prefSummaryFtpPassivePorts">Portas para conexão passiva FTP de dados. Pode ser uma única porta, uma lista ou um conjunto de portas. P.ex. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Tempo de inatividade do servidor</string>
-    <string name="prefSummaryIdleTimeout">O servidor encerrará as conexões inativas após este tempo (apenas FTP)</string>
-    <string name="prefSummaryIdleTimeoutV2">O servidor encerrará as conexões inativas após este tempo. Digitar 0 para desativar.</string>
+    <string name="prefSummaryIdleTimeout">O servidor encerrará as conexões inativas após este tempo em segundos (apenas FTP)</string>
+    <string name="prefSummaryIdleTimeoutV2">O servidor encerrará as conexões inativas após este tempo, em segundos. Ajuste para 0 para desativar.</string>
     <string name="prefTheme">Tema</string>
     <string name="prefSummaryTheme">A mudança do tema pode exigir o reinício do aplicativo.</string>
     <string name="prefTitleLogging">Log</string>

--- a/primitiveFTPd/res/values-pt-rPT/strings.xml
+++ b/primitiveFTPd/res/values-pt-rPT/strings.xml
@@ -76,7 +76,7 @@
     <string name="prefSummaryShowStartStopNotification">Mostra uma notificação a todo o tempo para ter mais uma forma rápida de arrancar/parar o(s) servidor(es).</string>
     <string name="prefSummaryFtpPassivePorts">Portas para ligações FTP passivas. Pode ser apenas uma porta, uma lista ou entre dois valores. Ex. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Tempo de servidor inactivo para expirar</string>
-    <string name="prefSummaryIdleTimeout">O servidor irá terminar ligações inactivas após este tempo (apenas FTP)</string>
+    <string name="prefSummaryIdleTimeout">O servidor irá terminar as ligações inactivas após este tempo em segundos (apenas FTP)</string>
     <string name="prefTheme">Tema</string>
     <string name="prefSummaryTheme">A mudança de tema poderá obrigar a um reinicio a aplicação.</string>
     <string name="prefTitleLogging">Registo</string>

--- a/primitiveFTPd/res/values-pt-rPT/strings.xml
+++ b/primitiveFTPd/res/values-pt-rPT/strings.xml
@@ -77,6 +77,7 @@
     <string name="prefSummaryFtpPassivePorts">Portas para ligações FTP passivas. Pode ser apenas uma porta, uma lista ou entre dois valores. Ex. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Tempo de servidor inactivo para expirar</string>
     <string name="prefSummaryIdleTimeout">O servidor irá terminar as ligações inactivas após este tempo em segundos (apenas FTP)</string>
+    <string name="prefSummaryIdleTimeoutV2">O servidor irá terminar as ligações inactivas após este tempo, em segundos. Definir para 0 para desactivar.</string>
     <string name="prefTheme">Tema</string>
     <string name="prefSummaryTheme">A mudança de tema poderá obrigar a um reinicio a aplicação.</string>
     <string name="prefTitleLogging">Registo</string>

--- a/primitiveFTPd/res/values-ru/strings.xml
+++ b/primitiveFTPd/res/values-ru/strings.xml
@@ -82,6 +82,7 @@
     <string name="widgetTextStop">Остановить ftpd</string>
     <string name="prefTitleIdleTimeout">Время бездействия</string>
     <string name="prefSummaryIdleTimeout">Сервер прервет простаивающие соединения через это время в секундах (только FTP).</string>
+    <string name="prefSummaryIdleTimeoutV2">Сервер прервет простаивающие соединения через это время в секундах. Установите 0 для отключения.</string>
     <string name="prefTitleStartOnOpen">Запуск при открытии</string>
     <string name="prefSummaryStartOnOpen">Запускать сервер при открытии приложения.</string>
     <string-array name="prefThemeNames">

--- a/primitiveFTPd/res/values-ru/strings.xml
+++ b/primitiveFTPd/res/values-ru/strings.xml
@@ -81,7 +81,7 @@
     <string name="widgetTextStart">Запустить ftpd</string>
     <string name="widgetTextStop">Остановить ftpd</string>
     <string name="prefTitleIdleTimeout">Время бездействия</string>
-    <string name="prefSummaryIdleTimeout">Сервер остановится после указанного времени бездействия (только для FTP)</string>
+    <string name="prefSummaryIdleTimeout">Сервер прервет простаивающие соединения через это время в секундах (только FTP).</string>
     <string name="prefTitleStartOnOpen">Запуск при открытии</string>
     <string name="prefSummaryStartOnOpen">Запускать сервер при открытии приложения.</string>
     <string-array name="prefThemeNames">

--- a/primitiveFTPd/res/values-zh/strings.xml
+++ b/primitiveFTPd/res/values-zh/strings.xml
@@ -62,6 +62,7 @@
     <string name="prefSummaryFtpPassivePorts">用于被动模式的数据端口。可以是单个端口，一系列端口或供随机选择的一个范围。例如 5678,5700-5710,5800,5900。</string>
     <string name="prefTitleIdleTimeout">服务器空闲超时</string>
     <string name="prefSummaryIdleTimeout">当连接空闲时间超过这一秒数后，服务器将会关闭连接（仅限 FTP）</string>
+    <string name="prefSummaryIdleTimeoutV2">当连接空闲超过此秒数时，服务器将关闭连接。 设置为0禁用。</string>
     <string name="prefTheme">主题</string>
     <string name="prefSummaryTheme">改变主题需要重启应用。</string>
     <string name="prefTitleLogging">日志</string>

--- a/primitiveFTPd/res/values/strings.xml
+++ b/primitiveFTPd/res/values/strings.xml
@@ -80,8 +80,8 @@
     <string name="prefTitleFtpPassivePorts">FTP Passive Ports</string>
     <string name="prefSummaryFtpPassivePorts">Ports for FTP passive data connection. May be a single port, a list or range of ports. E.g. 5678,5700-5710,5800,5900.</string>
     <string name="prefTitleIdleTimeout">Server Idle Timeout</string>
-    <string name="prefSummaryIdleTimeout">Server will terminate idle connections after this time (FTP only)</string>
-    <string name="prefSummaryIdleTimeoutV2">Server will terminate idle connections after this time. Set to 0 to disable.</string>
+    <string name="prefSummaryIdleTimeout">Server will terminate idle connections after this time in seconds (FTP only)</string>
+    <string name="prefSummaryIdleTimeoutV2">Server will terminate idle connections after this time in seconds. Set to 0 to disable.</string>
     <string name="prefTheme">Theme</string>
     <string name="prefSummaryTheme">Changing Theme may require to restart the app.</string>
     <string name="prefTitleLogging">Log</string>


### PR DESCRIPTION
The summary of the "Server Idle Timeout" setting, which can be seen in the graphical user interface, is ambiguous. 

The description reads:
> Server will terminate idle connections after this time. Set to 0 to disable.

An integer can be entered in the field. But it is not made clear in which time unit. Conceivable are _minutes_, _seconds_ or even _milliseconds_. This problem can be solved easily.

I changed the summary in a way that it is clear to the user that the timeout is set in _seconds_. To do this, I modified various `strings.xml`-files in `primitiveFTPd/res/values-*`. More precisely the keys `prefSummaryIdleTimeout` and `prefSummaryIdleTimeoutV2`. The change was done for all languages in which the two mentioned keys were already defined. Those are:

- English (`res/values/`)
- Arabic (`res/values-ar/`)
- German (`res/values-de/`)
- Greek (`res/values-el/`)
- Spanish (`res/values-es/`)
- French (`res/values-fr/`)
- Hungarian (`res/values-hu/`)
- Indonesian (`res/values-in/`) , whose correct two-letter abbreviation would be `id` 😉
- Italian (`res/values-it/`)
- Polish (`res/values-pl/`)
- Portuguese (`res/values-pt-rPT/`)
- Brazilian Portuguese (`res/values-pt-rBR/`)
- Russian (`res/values-ru/`)
- Chinese (`res/values-zh/`)

The translation was done with [DeepL](https://www.deepl.com) and [Google Translate](https://translate.google.com).

What the unit sought is, becomes clear when looking at the source code.  In the passages mentioned below, it is commented that the unit of the "idle time out"-setting is _seconds_. 

[passage#1](https://github.com/wolpi/prim-ftpd/blob/a992d980770fa343c85882b71133cff5d7da7e82/apache-ftpserver-1.1.1/core/src/main/java/org/apache/ftpserver/listener/ListenerFactory.java#L218), [passage#2](https://github.com/wolpi/prim-ftpd/blob/a992d980770fa343c85882b71133cff5d7da7e82/apache-ftpserver-1.1.1/core/src/main/java/org/apache/ftpserver/listener/Listener.java#L135), [passage#3](https://github.com/wolpi/prim-ftpd/blob/a992d980770fa343c85882b71133cff5d7da7e82/apache-ftpserver-1.1.1/core/src/main/java/org/apache/ftpserver/listener/nio/AbstractListener.java#L171)