### PR TITLE
UI translated to Catalan

### DIFF
--- a/primitiveFTPd/res/values-ca/strings.xml
+++ b/primitiveFTPd/res/values-ca/strings.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">primitive ftpd</string>
+    <string name="ifacesLabel">Interfície xarxa</string>
+    <string name="ipAddrLabel">Adreça IP</string>
+    <string name="ifacesError">Error: </string>
+    <string name="protocolLabel">Protocol</string>
+    <string name="portLabel">Port</string>
+    <string name="fingerprintsLabel">Empremtes de les claus</string>
+    <string name="allKeysFingerprintsLabel">Mostra empremtes de totes les claus</string>
+    <string name="generateKeysMessage">Voleu generar les claus?</string>
+    <string name="generatingKeysMessage">S'estan generant les claus…</string>
+    <string name="generate">Genera-les</string>
+    <string name="cancel">Cancel·la</string>
+    <string name="state">Estat</string>
+    <string name="serverStarted">En ús…</string>
+    <string name="serverStopped">Aturat</string>
+    <string name="permissionRequired">L'aplicació necessita el permís «%1$s» per a funcionar</string>
+    <string name="permissionNameStorage">Emmagatzematge</string>
+    <string name="quickSettingsServerStarted">pFTPd en ús…</string>
+    <string name="quickSettingsServerStopped">pFTPd aturat</string>
+    <string name="saveAs">Anomena i desa</string>
+    <string name="startService">Inicia el servidor</string>
+    <string name="stopService">Atura el servidor</string>
+    <string name="toggleService">Commuta l'inici/aturada del servidor</string>
+    <string name="notificationTitle">Servidor FTP</string>
+    <string name="haveToSetPassword">Primer heu d'establir una contrasenya</string>
+    <string name="haveToSetAuthMechanism">Primer heu de definir un mètode d'autenticació</string>
+    <string name="serverRunning">El servidor FTP s'està executant</string>
+    <string name="serverCouldNotBeStarted">No s'ha pogut iniciar el servidor. Error: </string>
+    <string name="portInvalid_v2">Port no vàlid: ha d'ésser des de 1024 a 64000.</string>
+    <string name="portsEqual_v2">Ambdós ports són iguals, això no és possible.</string>
+    <string name="restartServer">Reinicieu el servidor per a aplicar els canvis.</string>
+    <string name="invalidDir">La carpeta no és vàlida.</string>
+    <string name="couldNotReadKeyAuthKey">No s'ha pogut llegir la clau pública per a l'autenticació. Més informació al registre.</string>
+    <string name="ftpPassivePortsInvalid">La llista de ports d'FTP passiu no és vàlida.</string>
+    <string name="prefs">Preferències</string>
+    <string name="prefsCategoryTitleAuth">Autenticació</string>
+    <string name="prefsCategoryTitleConnectivity">Connectivitat</string>
+    <string name="prefsCategoryTitleUi">Interfície d'usuari</string>
+    <string name="prefsCategoryTitleSystem">Sistema</string>
+    <string name="prefTitleUser">Nom d'usuari</string>
+    <string name="prefSummaryUser">El nom de l'usuari del servidor FTP</string>
+    <string name="prefTitlePassword">Contrasenya</string>
+    <string name="prefSummaryPassword">La contrasenya de l'usuari del servidor FTP</string>
+    <string name="prefTitlePort">Port</string>
+    <string name="prefSummaryPort">El port del servidor FTP</string>
+    <string name="prefTitlePortSecure">Port segur</string>
+    <string name="prefSummaryPortSecure">El port del servidor FTP per a una connexió xifrada (SFTP)</string>
+    <string name="prefBindIp">Vincular a una IP</string>
+    <string name="prefSummaryBindIp">Si voleu que el(s) servidor(s) escoltin només una interfície de xarxa (adreça IP).</string>
+    <string name="prefTitleStartDir">Carpeta d'inici del servidor</string>
+    <string name="prefSummaryStartDir">Carpeta inicial en connectar-se al servidor.</string>
+    <string name="prefTitleAnnounce">Anuncia el servidor (LAN)</string>
+    <string name="prefSummaryAnnounce">Anuncia el servidor FTP en la xarxa local (LAN) via DNS-SD (Bonjour). Pot fer que l'aplicació falli en alguns dispositius.</string>
+    <string name="prefTitleAnnounceName">Nom del servidor</string>
+    <string name="prefSummaryAnnounceName">Nom amb què anunciar el servidor a la xarxa.</string>
+    <string name="prefTitleWakelock">Evita el mode d'espera</string>
+    <string name="prefSummaryWakelock">Evita el mode d'espera mentre el servidor estigui encès. El mode d'espera por causar interrupcions en les pujades i baixades.</string>
+    <string name="prefTitleWhichServerToStart">Servidor(s) a iniciar</string>
+    <string name="prefSummaryWhichServerToStart">Trieu si voleu iniciar només el servidor FTP, només l'SFTP, o ambdós.</string>
+    <string name="prefTitleStartOnBoot">Engega durant l'arrencada</string>
+    <string name="prefSummaryStartOnBoot">Engega el servidor durant l'arrencada del sistema.</string>
+    <string name="prefTitleStartOnOpen">Engega en obrir</string>
+    <string name="prefSummaryStartOnOpen">Engega el servidor en obrir l'aplicació.</string>
+    <string name="prefTitleShowConnectionInfoInNotification">Informació en l'àrea de notificacions</string>
+    <string name="prefSummaryShowConnectionInfoInNotification">Mostra informació de la connexió en la notificació (per exemple la IP).</string>
+    <string name="prefTitleSshowIpv4InNotification">Adreces IPv4 en la notificació</string>
+    <string name="prefSummaryShowIpv4InNotification">Mostra adreces IPv4 en la notificació, si està activada la informació en l'àrea de notificacions.</string>
+    <string name="prefTitleSshowIpv6InNotification">Adreces IPv6 en la notificació</string>
+    <string name="prefSummaryShowIpv6InNotification">Mostra adreces IPv6 en la notificació, si està activada la informació en l'àrea de notificacions.</string>
+    <string name="prefTitleShowStartStopNotification">Notificació d'engegada/aturada</string>
+    <string name="prefSummaryShowStartStopNotification">Mostra en tot moment una notificació per a permetre engegar i aturar el(s) servidor(s) d'una manera ràpida.</string>
+    <string name="prefTitlePubKeyAuth">Autenticació de clau pública</string>
+    <string name="prefSummaryPubKeyAuth">Si l'activeu, deseu la vostra clau pública SSH2 en %s. Només per a SFTP.</string>
+    <string name="prefSummaryPubKeyAuth_v2">Si l'activeu, deseu la vostra clau pública SSH2 en %s. El fitxer ha de tenir cada clau en una línia. Només per a SFTP.</string>
+    <string name="prefTitleAnonymousLogin">Sessió anònima</string>
+    <string name="prefSummaryAnonymousLogin">Permet als clients accedir al servidor sense usuari ni contrasenya.</string>
+    <string name="prefTitleFtpPassivePorts">Ports d'FTP passiu</string>
+    <string name="prefSummaryFtpPassivePorts">Els ports per a connexions FTP passives. Els valors poden ser, un sol port, o una llista de ports i intervals de ports. Per exemple 5678,5700-5710,5800,5900.</string>
+    <string name="prefTitleIdleTimeout">Temps d'inactivitat</string>
+    <string name="prefSummaryIdleTimeout">Es tancaran les connexions sense activitat després d'un temps, en segons. (Només FTP).</string>
+    <string name="prefSummaryIdleTimeoutV2">Es tancaran les connexions sense activitat després d'un temps, en segons. Poseu 0 per a desactivar-ho.</string>
+    <string name="prefTheme">Tema</string>
+    <string name="prefSummaryTheme">Canviar el tema pot requerir reiniciar l'aplicació.</string>
+    <string name="prefTitleLogging">Registre</string>
+    <string name="prefSummaryLogging">El registre permet analitzar errors. Si l'aplicació no funciona correctament en el vostre dispositiu, podeu enviar el registre als desenvolupadors. Pot requerir reiniciar l'aplicació.</string>
+    <string name="prefSummaryLoggingV2">El registre permet analitzar errors. Si l'aplicació no funciona correctament en el vostre dispositiu, podeu enviar el registre als desenvolupadors. Pot requerir reiniciar l'aplicació. Els registres es desen en %s.</string>
+    <string name="prefAllowedIpsPattern">Patró d'IPs permeses</string>
+    <string name="prefSummaryAllowedIpsPattern">Definiu amb un patró les adreces IP que poden connectar-se al servidor. Només podeu emprar un caràcter comodí (*), i ha d'ésser l'últim.</string>
+    <string name="prefTitleQuickSettingsRequiresUnlock">Desbloqueig per a configurar</string>
+    <string name="prefSummaryQuickSettingsRequiresUnlock">Si l'activeu, prémer el requadre de configuració ràpida demarà desbloquejar el dispositiu per a iniciar o aturar el servidor.</string>
+    <string name="prefRootCopyFiles">Root: emprar carpeta temporal</string>
+    <string name="prefSummaryRootCopyFiles">Accedir a fitxers amb l'ordre «dd» pot donar problemes en alguns dispositius. Si activeu aquesta opció, es copien primer a la carpeta «tmp» i, després, s'hi accedeix per mitjà del sistema de fitxers del dispositiu. Es recomana no activar-la si heu de trametre fitxers grans.</string>
+    <string name="licence">Llicència</string>
+    <string name="reset">Restableix</string>
+    <string name="widgetTextStart">engega (s)ftpd</string>
+    <string name="widgetTextStop">atura (s)ftpd</string>
+    <string name="isAnonymous">Usuari anònim: %1$b</string>
+    <string name="passwordPresent">Contrasenya: %1$b</string>
+    <string name="pubKeyAuth">Accés amb clau pública: %1$b</string>
+    <string name="selectServerAction">Trieu l'acció del servidor</string>
+    <string name="isServerRunning">S'està executant el servidor?</string>
+    <string name="storageType">Tipus d'emmagatzematge</string>
+    <string name="storageTypePlain">Sistema de fitxers</string>
+    <string name="storageTypePlainV2">Sistema de fitxers\nAccés només de lectura? Vegeu <a href="https://www.github.com/wolpi/prim-ftpd/">GitHub</a>.</string>
+    <string name="storageTypeRoot">Superusuari (requereix «root» accessible)</string>
+    <string name="storageTypeSaf">Entorn Android d'accés\na l'emmagatzematge (SAF). (P. ex. per a targetes SD)</string>
+    <string name="storageTypeRoSaf">SAF només de lectura (més ràpid)</string>
+    <string name="storageTypeVirtual">Carpetes virtuals (admet tots els tipus)</string>
+    <string name="safExplainHeading">Funcionament del SAF</string>
+    <string name="safExplain">El sistema us demanarà triar una carpeta; que serà accessible connectant-se al(s) servidor(s). De tant en tant és possible que es revoquin els permisos, i hàgiu de seleccionar la carpeta novament.</string>
+    <string name="selectedSafUri">URI triada per al SAF:</string>
+    <string name="startServerAndExit">engega només el servidor</string>
+    <string name="startServerAndUi">engega amb el servidor</string>
+    <string name="downloadOrSaveUrlToFile">Voleu descarregar-ho o desar la URL en un fitxer?</string>
+    <string name="download">Descarrega</string>
+    <string name="saveToTextFile">Desa</string>
+    <string name="open">Obre</string>
+    <string name="filepickerCreateFolderError">Error en crear la carpeta</string>
+    <string name="filepickerNewFolder">Carpeta nova</string>
+    <string name="filepickerNewFolderOk">@android:string/ok</string>
+    <string name="filepickerNewFolderCancel">@android:string/cancel</string>
+    <string name="filepickerListOk">@android:string/ok</string>
+    <string name="filepickerListCancel">@android:string/cancel</string>
+    <string name="filepickerName">Nom</string>
+    <string name="filepickerFilename">Nom del fitxer</string>
+    <string name="filepickerSelectSomethingFirst">Primer heu de triar quelcom</string>
+    <string name="filepickerNeedValidFilename">Doneu un fitxer vàlid</string>
+    <string name="quickShare">Enviament ràpid</string>
+    <string name="quickShareServerStarted">S'ha iniciat el servidor enviant un sol fitxer</string>
+    <string name="quickShareCouldNotStartServer">No s'ha pogut iniciar el servidor</string>
+    <string name="quickShareInfoNotification">Enviament ràpid de: %1s</string>
+    <string name="quickShareInfoNotificationV2">Enviament ràpid amb %1d fitxer(s)</string>
+    <string name="quickShareInfoActivity">Mode d'enviament ràpid per fitxer: %1s</string>
+    <string name="quickShareInfoActivityV2">Mode d'enviament ràpid per a %1d fitxer(s)</string>
+    <string name="clientActionsLabel">Registre accions client</string>
+    <string name="statsLabel">Mètriques</string>
+    <string name="statsTotalSent">Total enviat</string>
+    <string name="statsTotalReceived">Total rebut</string>
+    <string name="statsSentPerSec">Enviat per segon</string>
+    <string name="statsReceivedPerSec">Rebut per segon</string>
+    <string name="hasFullAccessToStorage">Accés total a emmagatzematge: %1$b</string>
+    <string name="hasNormalAccessToStorage">Accés (normal) a emmagatzematge: %1$b</string>
+    <string name="hasAccessToMediaLocation">Accés a dades de posició (geodades): %1$b</string>
+    <string name="Request">Canvia</string>
+    <string name="quickShareFiles">Enviament ràpid de fitxers:</string>
+    <string name="logFiles">Fitxers de registre:</string>
+    <string name="rootTmpFiles">Fitxers temporals d'accés amb «root»:</string>
+    <string name="delete">Elimina</string>
+    <string name="permReadLabelServerstatus">el servidor està en ús?</string>
+    <string name="permReadDescServerstatus">Permet saber si el servidor ftp/sftp està en ús.</string>
+    <string name="permWriteLabelServerstatus">engega i atura el servidor</string>
+    <string name="permWriteDescServerstatus">Permet engegar i aturar el servidor ftp/sftp.</string>
+    <string name="mobileUiShort">Mode mòbil</string>
+    <string name="mobileUiLong">Mode dispositiu mòbil</string>
+    <string name="tvUiShort">Mode TV</string>
+    <string name="tvUiLong">Mode televisió</string>
+    <string-array name="prefWhichServerToStartNames">
+        <item>FTP i SFTP</item>
+        <item>Només FTP</item>
+        <item>Només SFTP</item>
+    </string-array>
+    <string-array name="prefWhichServerToStartValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="prefThemeNames">
+        <item>Fosc</item>
+        <item>Clar</item>
+        <item>Determinat pel sistema</item>
+    </string-array>
+    <string-array name="prefThemeValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="prefLoggingNames">
+        <item>No fer registre</item>
+        <item>Registrar en fitxer de text</item>
+        <item>Registrar en Android</item>
+    </string-array>
+    <string-array name="prefLoggingValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
Fixes #308. Translated the `strings.xml` file from English to Catalan and placed it in the (new) `values-ca` folder.