### PR TITLE
Fix virtual folder names

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
@@ -12,10 +12,10 @@ public abstract class VirtualFileSystemView<
         RoSafType extends RoSafFile<MinaType>
         > {
 
-    public static final String PREFIX_FS = "/fs";
-    public static final String PREFIX_ROOT = "/superuser";
-    public static final String PREFIX_SAF = "/saf";
-    public static final String PREFIX_ROSAF = "/rosaf";
+    public static final String PREFIX_FS = "fs";
+    public static final String PREFIX_ROOT = "superuser";
+    public static final String PREFIX_SAF = "saf";
+    public static final String PREFIX_ROSAF = "rosaf";
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -48,28 +48,28 @@ public abstract class VirtualFileSystemView<
         logger.debug("getFile '{}', absolute: '{}'", file, absoluteVirtualPath);
         if ("/".equals(absoluteVirtualPath)) {
             return createFile(absoluteVirtualPath, null, true, pftpdService);
-        } else if (absoluteVirtualPath.startsWith(PREFIX_FS)) {
-            String realPath = toRealPath(absoluteVirtualPath, PREFIX_FS);
+        } else if (absoluteVirtualPath.startsWith("/" + PREFIX_FS)) {
+            String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_FS);
             logger.debug("Using FS '{}' for '{}'", realPath, absoluteVirtualPath);
             if ("/".equals(realPath)) {
                 realPath = pftpdService.getPrefsBean().getStartDir().getAbsolutePath();
-                absoluteVirtualPath = PREFIX_FS + realPath;
+                absoluteVirtualPath = "/" + PREFIX_FS + realPath;
                 logger.debug("  switching to FS default dir: '{}'", absoluteVirtualPath);
             }
             AbstractFile delegate = fsFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);
-        } else if (absoluteVirtualPath.startsWith(PREFIX_ROOT)) {
-            String realPath = toRealPath(absoluteVirtualPath, PREFIX_ROOT);
+        } else if (absoluteVirtualPath.startsWith("/" + PREFIX_ROOT)) {
+            String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_ROOT);
             logger.debug("Using ROOT '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = rootFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);
-        } else if (absoluteVirtualPath.startsWith(PREFIX_SAF)) {
-            String realPath = toRealPath(absoluteVirtualPath, PREFIX_SAF);
+        } else if (absoluteVirtualPath.startsWith("/" + PREFIX_SAF)) {
+            String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_SAF);
             logger.debug("Using SAF '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = safFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);
-        } else if (absoluteVirtualPath.startsWith(PREFIX_ROSAF)) {
-            String realPath = toRealPath(absoluteVirtualPath, PREFIX_ROSAF);
+        } else if (absoluteVirtualPath.startsWith("/" + PREFIX_ROSAF)) {
+            String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_ROSAF);
             logger.debug("Using ROSAF '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = roSafFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);


### PR DESCRIPTION
fixes #343

related #207 is fixed with #345

Note: This is my first ever Android code, tested on the emulator and on real phone (Samsung A8, Android 9.0).

### sshfs-win before (can't access the folders):

```
 Volume in drive X has no label.
 Volume Serial Number is 2C8E-EB18

 Directory of X:\

1970.01.01  02:00    <DIR>          \fs
1970.01.01  02:00    <DIR>          \rosaf
1970.01.01  02:00    <DIR>          \saf
1970.01.01  02:00    <DIR>          \superuser
               0 File(s)              0 bytes
               4 Dir(s)  1 073 741 824 000 bytes free
```

### After

```
 Volume in drive X has no label.
 Volume Serial Number is 6940-EBE8

 Directory of X:\

1970.01.01  02:00    <DIR>          fs
1970.01.01  02:00    <DIR>          rosaf
1970.01.01  02:00    <DIR>          saf
1970.01.01  02:00    <DIR>          superuser
               0 File(s)              0 bytes
               4 Dir(s)  1 073 741 824 000 bytes free
```

### SFTP Drive before (can access the folders with these strange names):

```
 Volume in drive X is lmagyar
 Volume Serial Number is 1234-5678

 Directory of X:\

1970.01.01  02:00    <DIR>          $fs$fs
1970.01.01  02:00    <DIR>          $fs$superuser
1970.01.01  02:00    <DIR>          $fs$saf
1970.01.01  02:00    <DIR>          $fs$rosaf
               0 File(s)              0 bytes
               4 Dir(s)  9 223 372 036 854 775 296 bytes free
```

### After

```
 Volume in drive X is android-emulator
 Volume Serial Number is 1234-5678

 Directory of X:\

1970.01.01  02:00    <DIR>          fs
1970.01.01  02:00    <DIR>          superuser
1970.01.01  02:00    <DIR>          saf
1970.01.01  02:00    <DIR>          rosaf
               0 File(s)              0 bytes
               4 Dir(s)  9 223 372 036 854 775 296 bytes free
```
