### PR TITLE
Fix rename on virtual folders

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFile.java
@@ -44,7 +44,7 @@ public class VirtualFtpFile extends VirtualFile<FtpFile> implements FtpFile {
     @Override
     public boolean move(FtpFile target) {
         logger.trace("move()");
-        return delegate != null && ((FtpFile) delegate).move(target);
+        return delegate != null && ((FtpFile) delegate).move((FtpFile) ((VirtualFtpFile) target).delegate);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
@@ -43,7 +43,7 @@ public class VirtualSshFile extends VirtualFile<SshFile> implements SshFile {
     @Override
     public boolean move(SshFile target) {
         logger.trace("move()");
-        return delegate != null && ((SshFile) delegate).move(target);
+        return delegate != null && ((SshFile) delegate).move((SshFile) ((VirtualSshFile) target).delegate);
     }
 
     @Override


### PR DESCRIPTION
fixes #207

Note: This is my first ever Java code, tested on real Phone (Samsung A8, Android 9.0, connecting with WinSCP), because rename doesn't work on the emulator, I mean even the plain SAF without virtual folders failed with rename, but it works on a real phone with real SD card (plain SAF and virtual folders also).