### PR TITLE
Fix new file upload on SAF and VirtualFS with SSHFS

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -225,4 +225,13 @@ public abstract class SafFile<T> extends AbstractFile {
 
         return null;
     }
+
+    boolean createNewFile() throws IOException {
+        logger.trace("[{}] createNewFile()", name);
+        try {
+		    return (documentFile = parentDocumentFile.createFile(null, name)) != null;
+        } catch (Exception e) {
+            throw new IOException("Failed to create file", e);
+        }
+    }
 }

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -229,7 +229,7 @@ public abstract class SafFile<T> extends AbstractFile {
     boolean createNewFile() throws IOException {
         logger.trace("[{}] createNewFile()", name);
         try {
-		    return (documentFile = parentDocumentFile.createFile(null, name)) != null;
+            return (documentFile = parentDocumentFile.createFile(null, name)) != null;
         } catch (Exception e) {
             throw new IOException("Failed to create file", e);
         }

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -226,6 +226,10 @@ public abstract class SafFile<T> extends AbstractFile {
         return null;
     }
 
+    // This method is the equivalent of java.io.File.createNewFile(), it creates the file and updates the cached properties of it.
+    // This method is required by SSHFS, because it calls STAT and later FSTAT on created new files,
+    // STAT requires a created new file, FSTAT requires updated properties.
+    // This method is not required by normal clients who simply open, write and close the file.
     boolean createNewFile() throws IOException {
         logger.trace("[{}] createNewFile()", name);
         try {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -43,7 +43,7 @@ public abstract class SafFile<T> extends AbstractFile {
     private DocumentFile documentFile;
     private final DocumentFile parentDocumentFile;
 
-    private final boolean writable;
+    private boolean writable;
 
     public SafFile(
             ContentResolver contentResolver,
@@ -229,9 +229,20 @@ public abstract class SafFile<T> extends AbstractFile {
     boolean createNewFile() throws IOException {
         logger.trace("[{}] createNewFile()", name);
         try {
-            return (documentFile = parentDocumentFile.createFile(null, name)) != null;
+            documentFile = parentDocumentFile.createFile(null, name);
         } catch (Exception e) {
             throw new IOException("Failed to create file", e);
         }
+
+        if (documentFile != null) {
+            lastModified = documentFile.lastModified();
+            size = 0;
+            readable = documentFile.canRead();
+            exists = true;
+            writable = documentFile.canWrite();
+            return true;
+        }
+
+        return false;
     }
 }

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -7,6 +7,7 @@ import org.apache.sshd.common.Session;
 import org.apache.sshd.common.file.SshFile;
 import org.primftpd.services.PftpdService;
 
+import java.io.IOException;
 import java.util.List;
 
 public class SafSshFile extends SafFile<SshFile> implements SshFile {
@@ -66,6 +67,12 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
         logger.trace("[{}] getOwner()", name);
         return session.getUsername();
     }
+
+	@Override
+	public boolean create() throws IOException {
+		logger.trace("[{}] create()", name);
+        return createNewFile();
+	}
 
     @Override
     public SshFile getParentFile() {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -68,11 +68,11 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
         return session.getUsername();
     }
 
-	@Override
-	public boolean create() throws IOException {
-		logger.trace("[{}] create()", name);
+    @Override
+    public boolean create() throws IOException {
+        logger.trace("[{}] create()", name);
         return createNewFile();
-	}
+    }
 
     @Override
     public SshFile getParentFile() {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -71,6 +71,9 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
     @Override
     public boolean create() throws IOException {
         logger.trace("[{}] create()", name);
+        // This call is required by SSHFS, because it calls STAT and later FSTAT on created new files,
+        // STAT requires a created new file, FSTAT requires updated properties.
+        // This call is not required by normal clients who simply open, write and close the file.
         return createNewFile();
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
@@ -4,6 +4,7 @@ import org.apache.sshd.common.Session;
 import org.apache.sshd.common.file.SshFile;
 import org.primftpd.services.PftpdService;
 
+import java.io.IOException;
 import java.util.List;
 
 public class VirtualSshFile extends VirtualFile<SshFile> implements SshFile {
@@ -52,6 +53,12 @@ public class VirtualSshFile extends VirtualFile<SshFile> implements SshFile {
         logger.trace("[{}] getOwner()", name);
         return session.getUsername();
     }
+
+	@Override
+	public boolean create() throws IOException {
+		logger.trace("[{}] create()", name);
+        return delegate != null && ((SshFile) delegate).create();
+	}
 
     @Override
     public boolean isExecutable() {

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
@@ -57,7 +57,14 @@ public class VirtualSshFile extends VirtualFile<SshFile> implements SshFile {
     @Override
     public boolean create() throws IOException {
         logger.trace("[{}] create()", name);
-        return delegate != null && ((SshFile) delegate).create();
+        if (delegate != null && ((SshFile) delegate).create()) {
+            lastModified = delegate.getLastModified();
+            size = 0;
+            readable = delegate.isReadable();
+            exists = true;
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
@@ -57,6 +57,9 @@ public class VirtualSshFile extends VirtualFile<SshFile> implements SshFile {
     @Override
     public boolean create() throws IOException {
         logger.trace("[{}] create()", name);
+        // This call and the update of the cached properties is required by SSHFS, because it calls STAT and later FSTAT on created new files,
+        // STAT requires a created new file, FSTAT requires updated properties.
+        // This call is not required by normal clients who simply open, write and close the file.
         if (delegate != null && ((SshFile) delegate).create()) {
             lastModified = delegate.getLastModified();
             size = 0;

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
@@ -54,11 +54,11 @@ public class VirtualSshFile extends VirtualFile<SshFile> implements SshFile {
         return session.getUsername();
     }
 
-	@Override
-	public boolean create() throws IOException {
-		logger.trace("[{}] create()", name);
+    @Override
+    public boolean create() throws IOException {
+        logger.trace("[{}] create()", name);
         return delegate != null && ((SshFile) delegate).create();
-	}
+    }
 
     @Override
     public boolean isExecutable() {


### PR DESCRIPTION
SSHFS after opening a ***new***, non-existent file for upload, assumes it is created and calls a STAT on it ([see](https://github.com/libfuse/sshfs/blob/master/sshfs.c#L2837)). And that STAT fails on SAF and virtual FS, because the file doesn't created, doesn't exists.

UPDATE: And SSHFS even calls FSTAT on this open file, so the created file's properties have to be updated on the already created object.

It is created on the "plain old" file-system, and that works with SSHFS. So I've added it for SAF and virtual. I'm sure it is not fast, but at least works. Tested on real phone: Android 9.0, Samsung A8.

I didn't change the root FS implementation, because I can't test that, my phone is not rooted.
