### PR TITLE
Make SAF, ROSAF and virtual directories searchable

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
@@ -84,4 +84,10 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
     public List<SshFile> listSshFiles() {
         return listFiles();
     }
+
+    @Override
+    public boolean isExecutable() {
+        logger.trace("[{}] isExecutable()", name);
+        return isDirectory;
+    }
 }

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -68,6 +68,12 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
     }
 
     @Override
+    public boolean isExecutable() {
+        logger.trace("[{}] isExecutable()", name);
+        return isDirectory;
+    }
+
+    @Override
     public SshFile getParentFile() {
         logger.trace("[{}] getParentFile()", name);
         String parentPath = Utils.parent(absPath);

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
@@ -53,6 +53,12 @@ public class VirtualSshFile extends VirtualFile<SshFile> implements SshFile {
     }
 
     @Override
+    public boolean isExecutable() {
+        logger.trace("[{}] isExecutable()", name);
+        return delegate != null ? delegate.isExecutable() : true;
+    }
+
+    @Override
     public SshFile getParentFile() {
         logger.trace("[{}] getParentFile()", name);
         return delegate != null ? ((SshFile)delegate).getParentFile() : null;


### PR DESCRIPTION
Plain old FS gets this info from the real FS, and folders are executable=searchable (rwxrwxrwx).

In case of SAF and ROSAF: set isExecutable() true for folders.
In case of virtual: use the backing FS or be default true (for the / and the /fs, etc. folders).

Without executable bit set, the folders created by SSHFS on the client can't be selected as working directories. (eg. `cd .../saf/Anything` results in "Access denied")

Note: The ROSAF part is not tested.