### PR TITLE
Bugfix to handle unsigned int8 message types that are >127

### DIFF
--- a/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
+++ b/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
@@ -457,7 +457,7 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
 
     protected void process(Buffer buffer) throws IOException {
         int length = buffer.getInt();
-        int type = buffer.getByte();
+        int type = ((int) buffer.getByte()) & 0xFF;
         int id = buffer.getInt();
         switch (type) {
             case SSH_FXP_INIT: {


### PR DESCRIPTION
It is needed for the extended commands. See the next PR #350