### PR TITLE
Add check-file SSH_FXP_EXTENDED functionality (calculating hash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You may download latest development snapshot from [GitHub packages](https://gith
 * Android 7 Quicksettings Tile
 * Optional root access
 * Optional support for Android Storage Access Framework to be able to write external SD-cards
+* Can calculate hash for complete files on server side (sftp extended command)
 
 ## Translation
 You may help translate this app in [hosted weblate](https://hosted.weblate.org/projects/pftpd/pftpd/).

--- a/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
+++ b/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.file.FileSystemAware;
@@ -894,8 +896,45 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
             }
             case SSH_FXP_EXTENDED: {
                 String extension = buffer.getString();
-                log.info("Received unsupported SSH_FXP_EXTENDED({})", extension);
-                sendStatus(id, SSH_FX_OP_UNSUPPORTED, "Command SSH_FXP_EXTENDED(" + extension + ") is unsupported or not implemented");
+                switch (extension) {
+                    case "check-file": {
+                        String handle = buffer.getString();
+                        String hashalgorithms = buffer.getString();
+                        long hashoffset = buffer.getLong();
+                        long hashlength = buffer.getLong();
+                        int blocksize = buffer.getInt();
+                        log.debug("Received SSH_FXP_EXTENDED({}(handle={}, hashalgorithms={}, offset={}, length={}, blocksize={}))",
+                            new Object[] { extension, handle, hashalgorithms, hashoffset, hashlength, blocksize });
+                        try {
+                            Handle p = handles.get(handle);
+                            if (!(p instanceof FileHandle)) {
+                                sendStatus(id, SSH_FX_FAILURE, handle);
+                            } else {
+                                FileHandle fh = (FileHandle) p;
+                                Object[] filehash = checkFileHash(fh, hashalgorithms, hashoffset, hashlength, blocksize);
+                                String hashalgorithm = (String)filehash[0];
+                                byte[] hash = (byte[])filehash[1];
+                                Buffer buf = new Buffer(extension.length() + hashalgorithm.length() + hash.length + 2*4 + 5);
+                                buf.putByte((byte) SSH_FXP_EXTENDED_REPLY);
+                                buf.putInt(id);
+                                buf.putString(extension);
+                                buf.putString(hashalgorithm);
+                                buf.putRawBytes(hash);
+                                send(buf);
+                            }
+                        } catch (NoSuchAlgorithmException e) {
+                            sendStatus(id, SSH_FX_OP_UNSUPPORTED, e.getMessage());
+                        } catch (UnsupportedOperationException e) {
+                            sendStatus(id, SSH_FX_OP_UNSUPPORTED, e.getMessage());
+                        } catch (IOException e) {
+                            sendStatus(id, SSH_FX_FAILURE, e.getMessage());
+                        }
+                    }
+                    default: {
+                        log.info("Received unsupported SSH_FXP_EXTENDED({})", extension);
+                        sendStatus(id, SSH_FX_OP_UNSUPPORTED, "Command SSH_FXP_EXTENDED(" + extension + ") is unsupported or not implemented");
+                    }
+                }
                 break;
             }
             default: {
@@ -1182,6 +1221,29 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
             attrs.put(SshFile.Attribute.LastModifiedTime, ((long) buffer.getInt()) * 1000);
         }
         return attrs;
+    }
+
+    protected Object[] checkFileHash(FileHandle fh, String hashalgorithms, long offset, long length, int blocksize) throws IOException,
+            NoSuchAlgorithmException, UnsupportedOperationException {
+        // TODO support multiple hash algorithms
+        // TODO support hashing blocks of the file, not only the whole file
+        String hashalgorithm = hashalgorithms.split(",")[0];
+        if (offset != 0 || length != 0 || blocksize != 0) {
+            throw new UnsupportedOperationException("Only offset=0, length=0, blocksize=0 is supported");
+        }
+
+        MessageDigest digest = MessageDigest.getInstance(hashalgorithm);
+        byte[] buffer = new byte[Buffer.MAX_LEN];
+        int readLen = 0;
+        while (true) {
+            readLen = fh.read(buffer, offset);
+            if (readLen <= 0) {
+                break;
+            }
+            offset += readLen;
+            digest.update(buffer, 0, readLen);
+        };
+        return new Object[]{hashalgorithm, digest.digest()};
     }
 
     protected void sendStatus(int id, int substatus, String msg) throws IOException {


### PR DESCRIPTION
Can be merged only after PR #349.

This is very useful for checking files during synchronization.

I gave up on rclone, osync and unison, because they are extremely slow over SSHFS, because SSHFS sends dozens of commands even for the simplest directory listing.

I started to implement a python script for fast bidirectional sync especially optimized for your sftp server (approx. 100 times faster check than the mentioned solutions above), and hashing the files on the first run speeds up operation even another approx 10 times). So this hashing is very useful.

***Note:*** The implemented version only acceps requests for hashing the whole file.