### PR TITLE
Fix setLastModified() exception on SAF

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/FileUtil.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FileUtil.java
@@ -1,0 +1,92 @@
+package org.primftpd.filesystem;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import android.os.storage.StorageManager;
+import android.provider.DocumentsContract;
+
+import androidx.annotation.Nullable;
+import androidx.documentfile.provider.DocumentFile;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+public final class FileUtil {
+    private static final String PRIMARY_VOLUME_NAME = "primary";
+
+    public static String getFullDocIdPathFromTreeUri(@Nullable final Uri treeUri, Context con) {
+        if (treeUri == null) return null;
+        String volumePath = getVolumePath(getVolumeIdFromTreeUri(treeUri),con);
+        if (volumePath == null) return File.separator;
+        if (volumePath.endsWith(File.separator))
+            volumePath = volumePath.substring(0, volumePath.length() - 1);
+
+        String documentPath = getDocumentPathFromTreeUri(treeUri);
+        if (documentPath.endsWith(File.separator))
+            documentPath = documentPath.substring(0, documentPath.length() - 1);
+
+        if (documentPath.length() > 0) {
+            if (documentPath.startsWith(File.separator))
+                return volumePath + documentPath;
+            else
+                return volumePath + File.separator + documentPath;
+        }
+        else return volumePath;
+    }
+
+    @SuppressLint("ObsoleteSdkInt")
+    private static String getVolumePath(final String volumeId, Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null;
+        try {
+            StorageManager mStorageManager =
+                    (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
+            Class<?> storageVolumeClazz = Class.forName("android.os.storage.StorageVolume");
+            Method getVolumeList = mStorageManager.getClass().getMethod("getVolumeList");
+            Method getUuid = storageVolumeClazz.getMethod("getUuid");
+            Method getPath = storageVolumeClazz.getMethod("getPath");
+            Method isPrimary = storageVolumeClazz.getMethod("isPrimary");
+            Object result = getVolumeList.invoke(mStorageManager);
+
+            final int length = Array.getLength(result);
+            for (int i = 0; i < length; i++) {
+                Object storageVolumeElement = Array.get(result, i);
+                String uuid = (String) getUuid.invoke(storageVolumeElement);
+                Boolean primary = (Boolean) isPrimary.invoke(storageVolumeElement);
+
+                // primary volume?
+                if (primary && PRIMARY_VOLUME_NAME.equals(volumeId))
+                    return (String) getPath.invoke(storageVolumeElement);
+
+                // other volumes?
+                if (uuid != null && uuid.equals(volumeId))
+                    return (String) getPath.invoke(storageVolumeElement);
+            }
+            // not found.
+            return null;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public static String getVolumeIdFromTreeUri(final Uri treeUri) {
+        final String docId = DocumentsContract.getTreeDocumentId(treeUri);
+        final String[] split = docId.split(":");
+        if (split.length > 0) return split[0];
+        else return null;
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP) 
+        private static String getDocumentPathFromTreeUri(final Uri treeUri) {
+        //final String docId = DocumentsContract.getTreeDocumentId(treeUri);
+        final String docId = DocumentsContract.getDocumentId(treeUri);
+        final String[] split = docId.split(":");
+        if ((split.length >= 2) && (split[1] != null)) return split[1];
+        else return File.separator;
+    }
+}

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -16,11 +16,17 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public abstract class SafFile<T> extends AbstractFile {
 
@@ -124,12 +130,9 @@ public abstract class SafFile<T> extends AbstractFile {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             try {
-                ContentValues updateValues = new ContentValues();
-                //time = Utils.sshTimeToFileTime(time);
-                updateValues.put(DocumentsContract.Document.COLUMN_LAST_MODIFIED, time);
                 Uri docUri = documentFile.getUri();
-                int updated = contentResolver.update(docUri, updateValues, "name="+name, null);
-                return updated == 1;
+                Path filePath = Paths.get(FileUtil.getFullDocIdPathFromTreeUri(docUri, pftpdService.getContext()));
+                Files.getFileAttributeView(filePath, BasicFileAttributeView.class).setTimes(FileTime.fromMillis(time), null, null);
             } catch (Exception e) {
                 String baseMsg = "could not set last modified time";
                 logger.error(baseMsg, e);

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -131,7 +131,7 @@ public abstract class SafFile<T> extends AbstractFile {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             try {
                 Uri docUri = documentFile.getUri();
-                Path filePath = Paths.get(FileUtil.getFullDocIdPathFromTreeUri(docUri, pftpdService.getContext()));
+                Path filePath = Paths.get(StorageManagerUtil.getFullDocIdPathFromTreeUri(docUri, pftpdService.getContext()));
                 Files.getFileAttributeView(filePath, BasicFileAttributeView.class).setTimes(FileTime.fromMillis(time), null, null);
             } catch (Exception e) {
                 String baseMsg = "could not set last modified time";

--- a/primitiveFTPd/src/org/primftpd/filesystem/StorageManagerUtil.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/StorageManagerUtil.java
@@ -16,40 +16,49 @@ import java.io.FileNotFoundException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 
-public final class FileUtil {
+public final class StorageManagerUtil {
     private static final String PRIMARY_VOLUME_NAME = "primary";
 
-    public static String getFullDocIdPathFromTreeUri(@Nullable final Uri treeUri, Context con) {
-        if (treeUri == null) return null;
-        String volumePath = getVolumePath(getVolumeIdFromTreeUri(treeUri),con);
-        if (volumePath == null) return File.separator;
-        if (volumePath.endsWith(File.separator))
+    public static String getFullDocIdPathFromTreeUri(@Nullable final Uri treeUri, Context context) {
+        if (treeUri == null) {
+            return null;
+        }
+        String volumePath = getVolumePath(getVolumeIdFromTreeUri(treeUri), context);
+        if (volumePath == null) {
+            return File.separator;
+        }
+        if (volumePath.endsWith(File.separator)) {
             volumePath = volumePath.substring(0, volumePath.length() - 1);
+        }
 
         String documentPath = getDocumentPathFromTreeUri(treeUri);
-        if (documentPath.endsWith(File.separator))
+        if (documentPath.endsWith(File.separator)) {
             documentPath = documentPath.substring(0, documentPath.length() - 1);
+        }
 
         if (documentPath.length() > 0) {
-            if (documentPath.startsWith(File.separator))
+            if (documentPath.startsWith(File.separator)) {
                 return volumePath + documentPath;
-            else
+            } else {
                 return volumePath + File.separator + documentPath;
+            }
+        } else {
+            return volumePath;
         }
-        else return volumePath;
     }
 
     @SuppressLint("ObsoleteSdkInt")
     private static String getVolumePath(final String volumeId, Context context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return null;
+        }
         try {
-            StorageManager mStorageManager =
-                    (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
-            Class<?> storageVolumeClazz = Class.forName("android.os.storage.StorageVolume");
+            StorageManager mStorageManager = (StorageManager) context.getSystemService(Context.STORAGE_SERVICE);
+            Class<?> storageVolumeClass = Class.forName("android.os.storage.StorageVolume");
             Method getVolumeList = mStorageManager.getClass().getMethod("getVolumeList");
-            Method getUuid = storageVolumeClazz.getMethod("getUuid");
-            Method getPath = storageVolumeClazz.getMethod("getPath");
-            Method isPrimary = storageVolumeClazz.getMethod("isPrimary");
+            Method getUuid = storageVolumeClass.getMethod("getUuid");
+            Method getPath = storageVolumeClass.getMethod("getPath");
+            Method isPrimary = storageVolumeClass.getMethod("isPrimary");
             Object result = getVolumeList.invoke(mStorageManager);
 
             final int length = Array.getLength(result);
@@ -59,12 +68,14 @@ public final class FileUtil {
                 Boolean primary = (Boolean) isPrimary.invoke(storageVolumeElement);
 
                 // primary volume?
-                if (primary && PRIMARY_VOLUME_NAME.equals(volumeId))
+                if (primary && PRIMARY_VOLUME_NAME.equals(volumeId)) {
                     return (String) getPath.invoke(storageVolumeElement);
+                }
 
                 // other volumes?
-                if (uuid != null && uuid.equals(volumeId))
+                if (uuid != null && uuid.equals(volumeId)) {
                     return (String) getPath.invoke(storageVolumeElement);
+                }
             }
             // not found.
             return null;
@@ -77,16 +88,21 @@ public final class FileUtil {
     public static String getVolumeIdFromTreeUri(final Uri treeUri) {
         final String docId = DocumentsContract.getTreeDocumentId(treeUri);
         final String[] split = docId.split(":");
-        if (split.length > 0) return split[0];
-        else return null;
+        if (split.length > 0) {
+            return split[0];
+        } else {
+            return null;
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP) 
-        private static String getDocumentPathFromTreeUri(final Uri treeUri) {
-        //final String docId = DocumentsContract.getTreeDocumentId(treeUri);
+    private static String getDocumentPathFromTreeUri(final Uri treeUri) {
         final String docId = DocumentsContract.getDocumentId(treeUri);
         final String[] split = docId.split(":");
-        if ((split.length >= 2) && (split[1] != null)) return split[1];
-        else return File.separator;
+        if ((split.length >= 2) && (split[1] != null)) {
+            return split[1];
+        } else {
+            return File.separator;
+        }
     }
 }

--- a/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
+++ b/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
@@ -601,10 +601,6 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
                     } else {
                         FileHandle fh = (FileHandle) p;
                         fh.write(data, offset);
-                        SshFile sshFile = fh.getFile();
-
-                        sshFile.setLastModified(new Date().getTime());
-                        
                         sendStatus(id, SSH_FX_OK, "");
                     }
                 } catch (IOException e) {


### PR DESCRIPTION
In theory it is not possible: `DocumentsContract.Document.COLUMN_LAST_MODIFIED` is read-only.

In reality it is possible: we can't write the SD card's files with the file API, but we can set the attributes with the file API (what we can't through SAF, "great" design).

The solution is a copy-paste from https://stackoverflow.com/questions/63495498/android-scoped-storage-getcontentresolver-update-column-last-modified/66681306#66681306

***Note:*** I also removed the `sshFile.setLastModified(new Date().getTime());` call in each SSH_FXP_WRITE
- setting the current time is the responsibility of the OS
- yes, it is in v0.14.0 mina/sshd/sftp, but as I see in the latest, it is removed there also https://github.com/apache/mina-sshd/blob/master/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java#L879

fixes #145

Tested on Android 9.0, Samsung A8