### PR TITLE
Allow listing / and /storage/emulated folders

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -25,9 +25,9 @@ public abstract class FsFile<T> extends AbstractFile {
 	protected final boolean injectedDirectory;
 
 	private final static Map<String, String[]> DIRECTORY_INJECTIONS = Map.ofEntries(
-		// entry("/",					new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"}),
-		entry("/",					new String[] {"storage"}),
-		entry("/storage/emulated",	new String[] {"0"})
+		// entry("/", new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"}),
+		entry("/", new String[] {"storage"}),
+		entry("/storage/emulated", new String[] {"0"})
 	);
 
 	private final static Set<String> CUSTOMIZED_DIRECTORIES;

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -14,6 +14,8 @@ import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import static java.util.Map.entry;    
 
 public abstract class FsFile<T> extends AbstractFile {
 
@@ -139,10 +141,25 @@ public abstract class FsFile<T> extends AbstractFile {
 		return success;
 	}
 
+	private final static Map<String, String[]> FOLDERS = Map.ofEntries(
+		// entry("/",					new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"}),
+		entry("/",					new String[] {"storage"}),
+		entry("/storage/emulated",	new String[] {"0"})
+	);
+
 	public List<T> listFiles() {
 		logger.trace("[{}] listFiles()", name);
 		postClientAction(ClientActionEvent.ClientAction.LIST_DIR);
 		File[] filesArray = file.listFiles();
+		if (filesArray == null) {
+			String[] folders = FOLDERS.get(file.getAbsolutePath());
+			if (folders != null) {
+				filesArray = new File[folders.length];
+				for (int i = 0; i < folders.length; i++) {
+					filesArray[i] = new File(file.getAbsolutePath() + File.separator + folders[i]);
+				}
+			}
+		}
 		if (filesArray != null) {
 			List<T> files = new ArrayList<>(filesArray.length);
 			for (File file : filesArray) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -25,8 +25,8 @@ public abstract class FsFile<T> extends AbstractFile {
 	protected final boolean injectedDirectory;
 
 	private final static Map<String, String[]> DIRECTORY_INJECTIONS = Map.ofEntries(
-		entry("/",					new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"}),
-		// entry("/",					new String[] {"storage"}),
+		// entry("/",					new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"}),
+		entry("/",					new String[] {"storage"}),
 		entry("/storage/emulated",	new String[] {"0"})
 	);
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -25,7 +25,7 @@ public abstract class FsFile<T> extends AbstractFile {
 	protected final boolean injectedDirectory;
 
 	private final static Map<String, String[]> DIRECTORY_INJECTIONS = Map.ofEntries(
-		// entry("/", new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"}),
+		// entry("/", new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"}), // comment out the line below if you enable this injection!!!
 		entry("/", new String[] {"storage"}),
 		entry("/storage/emulated", new String[] {"0"})
 	);

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
@@ -50,14 +50,9 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	}
 
 	@Override
-	public boolean isReadable() {
-		return super.isReadable() || isDirectory() && isExecutable();
-	}
-
-	@Override
 	public boolean isExecutable() {
 		logger.trace("[{}] isExecutable()", name);
-		return file.canExecute();
+		return injectedDirectory || file.canExecute();
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
@@ -50,6 +50,11 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	}
 
 	@Override
+	public boolean isReadable() {
+		return super.isReadable() || isDirectory() && isExecutable();
+	}
+
+	@Override
 	public boolean isExecutable() {
 		logger.trace("[{}] isExecutable()", name);
 		return file.canExecute();

--- a/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
+++ b/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
@@ -689,7 +689,7 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, path);
                     } else if (!p.isDirectory()) {
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, path);
-                    } else if (!p.isExecutable()) {
+                    } else if (!p.isReadable()) {
                         sendStatus(id, SSH_FX_PERMISSION_DENIED, path);
                     } else {
                         String handle = UUID.randomUUID().toString();
@@ -714,7 +714,7 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, p.getFile().getAbsolutePath());
                     } else if (!p.getFile().isDirectory()) {
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, p.getFile().getAbsolutePath());
-                    } else if (!p.getFile().isExecutable()) {
+                    } else if (!p.getFile().isReadable()) {
                         sendStatus(id, SSH_FX_PERMISSION_DENIED, p.getFile().getAbsolutePath());
                     } else {
                         DirectoryHandle dh = (DirectoryHandle) p;

--- a/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
+++ b/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
@@ -689,7 +689,7 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, path);
                     } else if (!p.isDirectory()) {
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, path);
-                    } else if (!p.isReadable()) {
+                    } else if (!p.isExecutable()) {
                         sendStatus(id, SSH_FX_PERMISSION_DENIED, path);
                     } else {
                         String handle = UUID.randomUUID().toString();
@@ -714,7 +714,7 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, p.getFile().getAbsolutePath());
                     } else if (!p.getFile().isDirectory()) {
                         sendStatus(id, SSH_FX_NO_SUCH_FILE, p.getFile().getAbsolutePath());
-                    } else if (!p.getFile().isReadable()) {
+                    } else if (!p.getFile().isExecutable()) {
                         sendStatus(id, SSH_FX_PERMISSION_DENIED, p.getFile().getAbsolutePath());
                     } else {
                         DirectoryHandle dh = (DirectoryHandle) p;


### PR DESCRIPTION
On (some?) non-rooted phones listing the `/` folder and the `/storage/emulated` returns nothing. Related #279 #293 #299 #305

~First workaround is to let at least return an empty list, that's why `isReadable()` is changed to `isExecutable()`.~

~Second~The workaround is more like a hack, because I couldn't find any way to list the root folders, though when I enter them directly (like `/system`), they work fine in read-only mode. So I've added a way to fake/inject any folder listing if the OS doesn't list anything for us.

Currently only the `/storage` and `/storage/emulated/0` is faked (the others are commented out in the code). This is helpful for the "average" user, because at least there is a path to the internal and external storage throught clicking in eg. WinSCP, without direct knowledge of the Android file-system's structure.