### PR TITLE
Handle StartDir differently in case of VirtFS

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
@@ -50,8 +50,6 @@ public abstract class VirtualFileSystemView<
             return createFile(absoluteVirtualPath, null, true, pftpdService);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_FS)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_FS);
-            String startDir = pftpdService.getPrefsBean().getStartDir().getAbsolutePath();
-            realPath = ("/".equals(startDir) ? "" : startDir) + "/" + ("/".equals(realPath) ? "" : realPath);
             logger.debug("Using FS '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = fsFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
@@ -1,8 +1,5 @@
 package org.primftpd.filesystem;
 
-import java.io.File;
-import java.nio.file.Paths;
-
 import org.primftpd.services.PftpdService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +50,7 @@ public abstract class VirtualFileSystemView<
             return createFile(absoluteVirtualPath, null, true, pftpdService);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_FS)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_FS);
-            realPath = Paths.get(pftpdService.getPrefsBean().getStartDir().getAbsolutePath(), realPath).toString();
+            realPath = pftpdService.getPrefsBean().getStartDir().getAbsolutePath() + "/" + realPath;
             logger.debug("Using FS '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = fsFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
@@ -1,5 +1,8 @@
 package org.primftpd.filesystem;
 
+import java.io.File;
+import java.nio.file.Paths;
+
 import org.primftpd.services.PftpdService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,12 +53,8 @@ public abstract class VirtualFileSystemView<
             return createFile(absoluteVirtualPath, null, true, pftpdService);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_FS)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_FS);
+            realPath = Paths.get(pftpdService.getPrefsBean().getStartDir().getAbsolutePath(), realPath).toString();
             logger.debug("Using FS '{}' for '{}'", realPath, absoluteVirtualPath);
-            if ("/".equals(realPath)) {
-                realPath = pftpdService.getPrefsBean().getStartDir().getAbsolutePath();
-                absoluteVirtualPath = "/" + PREFIX_FS + realPath;
-                logger.debug("  switching to FS default dir: '{}'", absoluteVirtualPath);
-            }
             AbstractFile delegate = fsFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_ROOT)) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
@@ -50,7 +50,8 @@ public abstract class VirtualFileSystemView<
             return createFile(absoluteVirtualPath, null, true, pftpdService);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_FS)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_FS);
-            realPath = pftpdService.getPrefsBean().getStartDir().getAbsolutePath() + "/" + realPath;
+            String startDir = pftpdService.getPrefsBean().getStartDir().getAbsolutePath();
+            realPath = ("/".equals(startDir) ? "" : startDir) + "/" + ("/".equals(realPath) ? "" : realPath);
             logger.debug("Using FS '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = fsFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
@@ -15,7 +15,7 @@ public class VirtualFtpFileSystemView extends VirtualFileSystemView<
         RoSafFtpFile> implements FileSystemView {
 
     private final User user;
-	private final File homeDir;
+    private final File homeDir;
     private FtpFile workingDir;
 
     public VirtualFtpFileSystemView(
@@ -28,7 +28,7 @@ public class VirtualFtpFileSystemView extends VirtualFileSystemView<
             User user) {
         super(fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView, pftpdService);
         this.user = user;
-		this.homeDir = homeDir;
+        this.homeDir = homeDir;
         workingDir = getHomeDirectory();
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
@@ -15,6 +15,7 @@ public class VirtualFtpFileSystemView extends VirtualFileSystemView<
         RoSafFtpFile> implements FileSystemView {
 
     private final User user;
+	private final File homeDir;
     private FtpFile workingDir;
 
     public VirtualFtpFileSystemView(
@@ -23,9 +24,11 @@ public class VirtualFtpFileSystemView extends VirtualFileSystemView<
             SafFtpFileSystemView safFileSystemView,
             RoSafFtpFileSystemView roSafFileSystemView,
             PftpdService pftpdService,
+            File homeDir,
             User user) {
         super(fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView, pftpdService);
         this.user = user;
+		this.homeDir = homeDir;
         workingDir = getHomeDirectory();
     }
 
@@ -42,13 +45,16 @@ public class VirtualFtpFileSystemView extends VirtualFileSystemView<
     @Override
     protected String absolute(String file) {
         logger.trace("  finding abs path for '{}' with wd '{}'", file, (workingDir != null ? workingDir.getAbsolutePath() : "null"));
+        if (workingDir == null) {
+            return file; // during c-tor
+        }
         return Utils.absolute(file, workingDir.getAbsolutePath());
     }
 
     @Override
     public FtpFile getHomeDirectory() {
-        logger.trace("getHomeDirectory()");
-        return createFile("/", null, pftpdService);
+        logger.trace("getHomeDirectory() -> {}", (homeDir != null ? homeDir.getAbsolutePath() : "null"));
+        return getFile("/" + PREFIX_FS + homeDir.getAbsolutePath());
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
@@ -26,7 +26,7 @@ public class VirtualSshFileSystemView extends VirtualFileSystemView<
             File homeDir,
             Session session) {
         super(fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView, pftpdService);
-		this.homeDir = homeDir;
+        this.homeDir = homeDir;
         this.session = session;
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
@@ -5,6 +5,8 @@ import org.apache.sshd.common.file.FileSystemView;
 import org.apache.sshd.common.file.SshFile;
 import org.primftpd.services.PftpdService;
 
+import java.io.File;
+
 public class VirtualSshFileSystemView extends VirtualFileSystemView<
         SshFile,
         FsSshFile,
@@ -12,6 +14,7 @@ public class VirtualSshFileSystemView extends VirtualFileSystemView<
         SafSshFile,
         RoSafSshFile> implements FileSystemView {
 
+    private final File homeDir;
     private final Session session;
 
     public VirtualSshFileSystemView(
@@ -20,8 +23,10 @@ public class VirtualSshFileSystemView extends VirtualFileSystemView<
             SafSshFileSystemView safFileSystemView,
             RoSafSshFileSystemView roSafFileSystemView,
             PftpdService pftpdService,
+            File homeDir,
             Session session) {
         super(fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView, pftpdService);
+		this.homeDir = homeDir;
         this.session = session;
     }
 
@@ -37,7 +42,7 @@ public class VirtualSshFileSystemView extends VirtualFileSystemView<
 
     @Override
     protected String absolute(String file) {
-        return Utils.absoluteOrHome(file, "/");
+        return Utils.absoluteOrHome(file, "/" + PREFIX_FS + homeDir.getAbsolutePath());
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
@@ -153,6 +153,7 @@ public class FtpServerService extends AbstractServerService
 											FtpServerService.this,
 											user),
 									FtpServerService.this,
+									prefsBean.getStartDir(),
 									user
 							);
 					}

--- a/primitiveFTPd/src/org/primftpd/services/SshServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/SshServerService.java
@@ -238,6 +238,7 @@ public class SshServerService extends AbstractServerService
 											SshServerService.this,
 											session),
 									SshServerService.this,
+									prefsBean.getStartDir(),
 									session
 							);
 					}


### PR DESCRIPTION
***UPDATE: complete rewrite of this comment***

Without this PR, pftpd VirtFS behaves errorneously:
- if eg. `/storage/emulated/0` is selected as startDir
  - SSHFS fails, can't see anything under `/fs`
  - WinSCP behaves strangely, it "jumps" from `/fs` to `/fs/storage/emulated/0`, that's OK, we can `..` out, and when on `/fs` again, it shows the startDir's content, but can't access the folders in it anymore, so gets broken
- only when `/` is the startDir, works everything

With this PR:
- ~the startDir's content is seen under `/fs`, eg. we have `/fs/Android` if startDir is `/storage/emulated/0` or we have `/fs/storage` if startDir is `/`~
- _we've got real home folders for virtFS SFTP and FTP, pointing to eg. `/fs/storage/emulated/0`_
- both SSHFS and WinSCP works fine ~(Note: SSHFS must select `/` as start folder)~
- ~this is analogous to the `/saf` and `/rosaf` folders, where we can see the content of the selected SD card folder~

---

Just fun fact: I made a version (https://github.com/lmagyar/prim-ftpd/tree/dev-dual-root-and-home-for-sshfs), where depending on SSHFS's start dir, `/` or nothing=user's home, it was able to see the `/` folder under `/fs` (when `/` is SSHFS's start dir), or the selected startDir, eg. `/storage/emulated/0` under `/fs` (when `` is the SSHFS start dir), it was soo cool, but WinSCP got completely broken and couldn't figure out the reason, even my fake symlink experiments on `/fs` etc. folders were broken, so gave up. :(