### PR TITLE
Do not create sample authorized_keys file at old location

### DIFF
--- a/primitiveFTPd/src/org/primftpd/util/SampleAuthKeysFileCreator.java
+++ b/primitiveFTPd/src/org/primftpd/util/SampleAuthKeysFileCreator.java
@@ -16,7 +16,6 @@ public class SampleAuthKeysFileCreator
 	public void createSampleAuthorizedKeysFiles(Context context) {
 		String[] paths = new String[]{
 				Defaults.pubKeyAuthKeyPath(context),
-				Defaults.PUB_KEY_AUTH_KEY_PATH_OLD,
 		};
 
 		for (String path : paths) {


### PR DESCRIPTION
As I see, the new location is at:
- `/storage/emulated/0/Android/data/org.primftpd/files/.ssh`

But the app also reads all the old locations at 
- `/storage/emulated/0/.ssh/authorized_key`
- `/storage/emulated/0/.ssh/authorized_key.pub`

On start it creates a sample file if there is no file. But it creates the sample at one of the old locations also. I don't see why is it necessary. This was [comitted](https://github.com/wolpi/prim-ftpd/commit/d8283f16e513dddff6b6cac9efa0b5d2ef143b19#diff-8b01d76f3ca3bf8418ac7bc420671b0b4d1c1672cbeb663ec72568471ef77a2c) this way originally, hasn't changed, but I think we shouldn't create a sample file at an "old" location.