### PR TITLE
Fix Android bug on FAT32/exFAT SD card time resolution and mtime caching

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -53,7 +53,7 @@ public abstract class FsFile<T> extends AbstractFile {
 		super(
 				file.getAbsolutePath(),
 				file.getName(),
-				correctTime(fileSystemView, file.getAbsolutePath(), file.lastModified()),
+				fileSystemView.getCorrectedTime(file.getAbsolutePath(), file.lastModified()),
 				file.length(),
 				file.canRead(),
 				file.exists(),
@@ -63,11 +63,6 @@ public abstract class FsFile<T> extends AbstractFile {
 		this.name = file.getName();
 		this.fileSystemView = fileSystemView;
 		this.injectedDirectory = file.isDirectory() && INJECTIONS_AND_CHILDREN.contains(file.getAbsolutePath());
-	}
-
-	private static long correctTime(FsFileSystemView fileSystemView, String abs, long time) {
-		int timeResolution = fileSystemView.getTimeResolution(abs);
-		return (time / timeResolution) * timeResolution;
 	}
 
 	protected abstract T createFile(File file, PftpdService pftpdService);
@@ -151,7 +146,7 @@ public abstract class FsFile<T> extends AbstractFile {
 
 	public boolean setLastModified(long time) {
 		logger.trace("[{}] setLastModified({})", name, Long.valueOf(time));
-		long correctedTime = correctTime(fileSystemView, absPath, time);
+		long correctedTime = fileSystemView.getCorrectedTime(absPath, time);
 		return file.setLastModified(correctedTime);
 	}
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -25,7 +25,6 @@ public abstract class FsFile<T> extends AbstractFile {
 	protected final File file;
     protected final FsFileSystemView fileSystemView;
 	protected final boolean injectedDirectory;
-	protected final int timeResolution;
 
 	private final static Map<String, String[]> DIRECTORY_INJECTIONS;
 	static {
@@ -64,11 +63,9 @@ public abstract class FsFile<T> extends AbstractFile {
 		this.name = file.getName();
 		this.fileSystemView = fileSystemView;
 		this.injectedDirectory = file.isDirectory() && INJECTIONS_AND_CHILDREN.contains(file.getAbsolutePath());
-		this.timeResolution = fileSystemView.getTimeResolution(file.getAbsolutePath());
 
-		if (timeResolution != 1) {
-			this.lastModified = (this.lastModified / timeResolution) * timeResolution;
-		}
+		int timeResolution = fileSystemView.getTimeResolution(file.getAbsolutePath());
+		this.lastModified = (this.lastModified / timeResolution) * timeResolution;
 	}
 
 	protected abstract T createFile(File file, PftpdService pftpdService);
@@ -152,6 +149,7 @@ public abstract class FsFile<T> extends AbstractFile {
 
 	public boolean setLastModified(long time) {
 		logger.trace("[{}] setLastModified({})", name, Long.valueOf(time));
+		int timeResolution = fileSystemView.getTimeResolution(file.getAbsolutePath());
 		long convertedTime = (time / timeResolution) * timeResolution;
 		return file.setLastModified(convertedTime);
 	}

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -23,7 +23,7 @@ import java.util.Set;
 public abstract class FsFile<T> extends AbstractFile {
 
 	protected final File file;
-    protected final FsFileSystemView fileSystemView;
+	protected final FsFileSystemView fileSystemView;
 	protected final boolean injectedDirectory;
 
 	private final static Map<String, String[]> DIRECTORY_INJECTIONS;
@@ -47,7 +47,7 @@ public abstract class FsFile<T> extends AbstractFile {
 			}
 		}
 		INJECTIONS_AND_CHILDREN = Collections.unmodifiableSet(tmp);
-    }
+	}
 
 	public FsFile(File file, PftpdService pftpdService, FsFileSystemView fileSystemView) {
 		super(

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -24,6 +24,7 @@ public abstract class FsFile<T> extends AbstractFile {
 
 	protected final File file;
 	protected final boolean injectedDirectory;
+	protected final int timeResolution;
 
 	private final static Map<String, String[]> DIRECTORY_INJECTIONS;
 	static {
@@ -48,11 +49,11 @@ public abstract class FsFile<T> extends AbstractFile {
 		INJECTIONS_AND_CHILDREN = Collections.unmodifiableSet(tmp);
     }
 
-	public FsFile(File file, PftpdService pftpdService) {
+	public FsFile(File file, PftpdService pftpdService, int timeResolution) {
 		super(
 				file.getAbsolutePath(),
 				file.getName(),
-				file.lastModified(),
+				(file.lastModified() / timeResolution) * timeResolution,
 				file.length(),
 				file.canRead(),
 				file.exists(),
@@ -61,6 +62,7 @@ public abstract class FsFile<T> extends AbstractFile {
 		this.file = file;
 		this.name = file.getName();
 		this.injectedDirectory = file.isDirectory() && INJECTIONS_AND_CHILDREN.contains(file.getAbsolutePath());
+		this.timeResolution = timeResolution;
 	}
 
 	protected abstract T createFile(File file, PftpdService pftpdService);
@@ -144,7 +146,8 @@ public abstract class FsFile<T> extends AbstractFile {
 
 	public boolean setLastModified(long time) {
 		logger.trace("[{}] setLastModified({})", name, Long.valueOf(time));
-		return file.setLastModified(time);
+		long convertedTime = (time / timeResolution) * timeResolution;
+		return file.setLastModified(convertedTime);
 	}
 
 	public boolean mkdir() {

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -23,6 +23,7 @@ import java.util.Set;
 public abstract class FsFile<T> extends AbstractFile {
 
 	protected final File file;
+    protected final FsFileSystemView fileSystemView;
 	protected final boolean injectedDirectory;
 	protected final int timeResolution;
 
@@ -49,7 +50,7 @@ public abstract class FsFile<T> extends AbstractFile {
 		INJECTIONS_AND_CHILDREN = Collections.unmodifiableSet(tmp);
     }
 
-	public FsFile(File file, PftpdService pftpdService, int timeResolution) {
+	public FsFile(File file, PftpdService pftpdService, int timeResolution, FsFileSystemView fileSystemView) {
 		super(
 				file.getAbsolutePath(),
 				file.getName(),
@@ -63,6 +64,7 @@ public abstract class FsFile<T> extends AbstractFile {
 		this.name = file.getName();
 		this.injectedDirectory = file.isDirectory() && INJECTIONS_AND_CHILDREN.contains(file.getAbsolutePath());
 		this.timeResolution = timeResolution;
+		this.fileSystemView = fileSystemView;
 	}
 
 	protected abstract T createFile(File file, PftpdService pftpdService);

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -50,11 +50,11 @@ public abstract class FsFile<T> extends AbstractFile {
 		INJECTIONS_AND_CHILDREN = Collections.unmodifiableSet(tmp);
     }
 
-	public FsFile(File file, PftpdService pftpdService, int timeResolution, FsFileSystemView fileSystemView) {
+	public FsFile(File file, PftpdService pftpdService, FsFileSystemView fileSystemView) {
 		super(
 				file.getAbsolutePath(),
 				file.getName(),
-				(file.lastModified() / timeResolution) * timeResolution,
+				file.lastModified(),
 				file.length(),
 				file.canRead(),
 				file.exists(),
@@ -62,9 +62,13 @@ public abstract class FsFile<T> extends AbstractFile {
 				pftpdService);
 		this.file = file;
 		this.name = file.getName();
-		this.injectedDirectory = file.isDirectory() && INJECTIONS_AND_CHILDREN.contains(file.getAbsolutePath());
-		this.timeResolution = timeResolution;
 		this.fileSystemView = fileSystemView;
+		this.injectedDirectory = file.isDirectory() && INJECTIONS_AND_CHILDREN.contains(file.getAbsolutePath());
+		this.timeResolution = fileSystemView.getTimeResolution(file.getAbsolutePath());
+
+		if (timeResolution != 1) {
+			this.lastModified = (this.lastModified / timeResolution) * timeResolution;
+		}
 	}
 
 	protected abstract T createFile(File file, PftpdService pftpdService);

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
@@ -26,7 +26,7 @@ public abstract class FsFileSystemView<T extends FsFile<X>, X> {
 		this.pftpdService = pftpdService;
 	}
 
-	protected int getTimeResolution(String abs) {
+	public int getTimeResolution(String abs) {
 		return safVolumePath != null && abs.startsWith(safVolumePath) ? safTimeResolution : 1;
 	}
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
@@ -26,8 +26,9 @@ public abstract class FsFileSystemView<T extends FsFile<X>, X> {
 		this.pftpdService = pftpdService;
 	}
 
-	public int getTimeResolution(String abs) {
-		return safVolumePath != null && abs.startsWith(safVolumePath) ? safTimeResolution : 1;
+	public long getCorrectedTime(String abs, long time) {
+		int timeResolution = safVolumePath != null && abs.startsWith(safVolumePath) ? safTimeResolution : 1;
+		return (time / timeResolution) * timeResolution;
 	}
 
 	public T getFile(String file) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
@@ -1,5 +1,8 @@
 package org.primftpd.filesystem;
 
+import android.content.Context;
+import android.net.Uri;
+
 import org.primftpd.services.PftpdService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,14 +12,22 @@ import java.io.File;
 public abstract class FsFileSystemView<T extends FsFile<X>, X> {
 
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
+	private final String safVolumePath;
+	private final int safTimeResolution;
 	protected final PftpdService pftpdService;
 
 	protected abstract T createFile(File file, PftpdService pftpdService);
 
 	protected abstract String absolute(String file);
 
-	public FsFileSystemView(PftpdService pftpdService) {
+	public FsFileSystemView(Context context, Uri safStartUrl, PftpdService pftpdService) {
+        this.safTimeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(safStartUrl);
+		this.safVolumePath = safTimeResolution != 1 ? StorageManagerUtil.getVolumePathFromTreeUri(safStartUrl, context) : null;
 		this.pftpdService = pftpdService;
+	}
+
+	protected int getTimeResolution(String abs) {
+		return safVolumePath != null && abs.startsWith(safVolumePath) ? safTimeResolution : 1;
 	}
 
 	public T getFile(String file) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
@@ -21,7 +21,7 @@ public abstract class FsFileSystemView<T extends FsFile<X>, X> {
 	protected abstract String absolute(String file);
 
 	public FsFileSystemView(Context context, Uri safStartUrl, PftpdService pftpdService) {
-        this.safTimeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(safStartUrl);
+		this.safTimeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(safStartUrl);
 		this.safVolumePath = safTimeResolution != 1 ? StorageManagerUtil.getVolumePathFromTreeUri(safStartUrl, context) : null;
 		this.pftpdService = pftpdService;
 	}

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
@@ -14,6 +14,10 @@ public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 		this.user = user;
 	}
 
+	private FsFtpFileSystemView getFileSystemView() {
+		return (FsFtpFileSystemView)fileSystemView;
+	}
+
 	@Override
 	public String getClientIp() {
 		return FtpUtils.getClientIp(user);
@@ -21,7 +25,7 @@ public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 
 	@Override
 	protected FtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, (FsFtpFileSystemView)fileSystemView, user);
+		return new FsFtpFile(file, pftpdService, getFileSystemView(), user);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
@@ -9,8 +9,8 @@ import org.primftpd.services.PftpdService;
 public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 	private final User user;
 
-	public FsFtpFile(File file, PftpdService pftpdService, int timeResolution, User user) {
-		super(file, pftpdService, timeResolution);
+	public FsFtpFile(File file, PftpdService pftpdService, int timeResolution, FsFtpFileSystemView fileSystemView, User user) {
+		super(file, pftpdService, timeResolution, fileSystemView);
 		this.user = user;
 	}
 
@@ -21,7 +21,7 @@ public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 
 	@Override
 	protected FtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, timeResolution, user);
+		return new FsFtpFile(file, pftpdService, fileSystemView.getTimeResolution(file.getAbsolutePath()), (FsFtpFileSystemView)fileSystemView, user);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
@@ -9,8 +9,8 @@ import org.primftpd.services.PftpdService;
 public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 	private final User user;
 
-	public FsFtpFile(File file, PftpdService pftpdService, int timeResolution, FsFtpFileSystemView fileSystemView, User user) {
-		super(file, pftpdService, timeResolution, fileSystemView);
+	public FsFtpFile(File file, PftpdService pftpdService, FsFtpFileSystemView fileSystemView, User user) {
+		super(file, pftpdService, fileSystemView);
 		this.user = user;
 	}
 
@@ -21,7 +21,7 @@ public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 
 	@Override
 	protected FtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, fileSystemView.getTimeResolution(file.getAbsolutePath()), (FsFtpFileSystemView)fileSystemView, user);
+		return new FsFtpFile(file, pftpdService, (FsFtpFileSystemView)fileSystemView, user);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
@@ -9,8 +9,8 @@ import org.primftpd.services.PftpdService;
 public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 	private final User user;
 
-	public FsFtpFile(File file, PftpdService pftpdService, User user) {
-		super(file, pftpdService);
+	public FsFtpFile(File file, PftpdService pftpdService, int timeResolution, User user) {
+		super(file, pftpdService, timeResolution);
 		this.user = user;
 	}
 
@@ -21,7 +21,7 @@ public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 
 	@Override
 	protected FtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, user);
+		return new FsFtpFile(file, pftpdService, timeResolution, user);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
@@ -26,7 +26,7 @@ public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> im
 
 	@Override
 	protected FsFtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), user);
+		return new FsFtpFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), this, user);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
@@ -1,5 +1,8 @@
 package org.primftpd.filesystem;
 
+import android.content.Context;
+import android.net.Uri;
+
 import java.io.File;
 
 import org.apache.ftpserver.ftplet.FtpFile;
@@ -14,8 +17,8 @@ public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> im
 	private final File homeDir;
 	private FsFtpFile workingDir;
 
-	public FsFtpFileSystemView(PftpdService pftpdService, File homeDir, User user) {
-		super(pftpdService);
+	public FsFtpFileSystemView(Context context, Uri safStartUrl, PftpdService pftpdService, File homeDir, User user) {
+		super(context, safStartUrl, pftpdService);
 		this.homeDir = homeDir;
 		workingDir = getHomeDirectory();
 		this.user = user;
@@ -23,7 +26,7 @@ public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> im
 
 	@Override
 	protected FsFtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, user);
+		return new FsFtpFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), user);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
@@ -26,7 +26,7 @@ public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> im
 
 	@Override
 	protected FsFtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), this, user);
+		return new FsFtpFile(file, pftpdService, this, user);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
@@ -10,10 +10,12 @@ import java.util.List;
 
 public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	private final Session session;
+    private final FsSshFileSystemView fileSystemView;
 
-	public FsSshFile(File file, PftpdService pftpdService, Session session) {
-		super(file, pftpdService);
+	public FsSshFile(File file, PftpdService pftpdService, int timeResolution, Session session, FsSshFileSystemView fileSystemView) {
+		super(file, pftpdService, timeResolution);
 		this.session = session;
+		this.fileSystemView = fileSystemView;
 	}
 
 	@Override
@@ -23,7 +25,7 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 
 	@Override
 	protected SshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, session);
+		return new FsSshFile(file, pftpdService, timeResolution, session, fileSystemView);
 	}
 
 	@Override
@@ -46,7 +48,12 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	@Override
 	public SshFile getParentFile() {
 		logger.trace("[{}] getParentFile()", name);
-		return new FsSshFile(file.getParentFile(), pftpdService, session);
+        String parentPath = file.getParent();
+        if (parentPath == null || parentPath.length() == 0) {
+            parentPath = File.separator;
+        }
+        logger.trace("[{}]   getParentFile() -> {}", name, parentPath);
+        return fileSystemView.getFile(parentPath);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
@@ -11,8 +11,8 @@ import java.util.List;
 public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	private final Session session;
 
-	public FsSshFile(File file, PftpdService pftpdService, int timeResolution, FsSshFileSystemView fileSystemView, Session session) {
-		super(file, pftpdService, timeResolution, fileSystemView);
+	public FsSshFile(File file, PftpdService pftpdService, FsSshFileSystemView fileSystemView, Session session) {
+		super(file, pftpdService, fileSystemView);
 		this.session = session;
 	}
 
@@ -23,7 +23,7 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 
 	@Override
 	protected SshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, fileSystemView.getTimeResolution(file.getAbsolutePath()), (FsSshFileSystemView)fileSystemView, session);
+		return new FsSshFile(file, pftpdService, (FsSshFileSystemView)fileSystemView, session);
 	}
 
 	@Override
@@ -46,8 +46,7 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	@Override
 	public SshFile getParentFile() {
 		logger.trace("[{}] getParentFile()", name);
-		File parentFile = file.getParentFile();
-		return new FsSshFile(parentFile, pftpdService, fileSystemView.getTimeResolution(parentFile.getAbsolutePath()), (FsSshFileSystemView)fileSystemView, session);
+		return new FsSshFile(file.getParentFile(), pftpdService, (FsSshFileSystemView)fileSystemView, session);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
@@ -16,6 +16,10 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 		this.session = session;
 	}
 
+	private FsSshFileSystemView getFileSystemView() {
+		return (FsSshFileSystemView)fileSystemView;
+	}
+
 	@Override
 	public String getClientIp() {
 		return SshUtils.getClientIp(session);
@@ -23,7 +27,7 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 
 	@Override
 	protected SshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, (FsSshFileSystemView)fileSystemView, session);
+		return new FsSshFile(file, pftpdService, getFileSystemView(), session);
 	}
 
 	@Override
@@ -46,7 +50,7 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	@Override
 	public SshFile getParentFile() {
 		logger.trace("[{}] getParentFile()", name);
-		return new FsSshFile(file.getParentFile(), pftpdService, (FsSshFileSystemView)fileSystemView, session);
+		return new FsSshFile(file.getParentFile(), pftpdService, getFileSystemView(), session);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
@@ -10,12 +10,10 @@ import java.util.List;
 
 public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	private final Session session;
-    private final FsSshFileSystemView fileSystemView;
 
-	public FsSshFile(File file, PftpdService pftpdService, int timeResolution, Session session, FsSshFileSystemView fileSystemView) {
-		super(file, pftpdService, timeResolution);
+	public FsSshFile(File file, PftpdService pftpdService, int timeResolution, FsSshFileSystemView fileSystemView, Session session) {
+		super(file, pftpdService, timeResolution, fileSystemView);
 		this.session = session;
-		this.fileSystemView = fileSystemView;
 	}
 
 	@Override
@@ -25,7 +23,7 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 
 	@Override
 	protected SshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, timeResolution, session, fileSystemView);
+		return new FsSshFile(file, pftpdService, fileSystemView.getTimeResolution(file.getAbsolutePath()), (FsSshFileSystemView)fileSystemView, session);
 	}
 
 	@Override
@@ -48,12 +46,8 @@ public class FsSshFile extends FsFile<SshFile> implements SshFile {
 	@Override
 	public SshFile getParentFile() {
 		logger.trace("[{}] getParentFile()", name);
-        String parentPath = file.getParent();
-        if (parentPath == null || parentPath.length() == 0) {
-            parentPath = File.separator;
-        }
-        logger.trace("[{}]   getParentFile() -> {}", name, parentPath);
-        return fileSystemView.getFile(parentPath);
+		File parentFile = file.getParentFile();
+		return new FsSshFile(parentFile, pftpdService, fileSystemView.getTimeResolution(parentFile.getAbsolutePath()), (FsSshFileSystemView)fileSystemView, session);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
@@ -23,7 +23,7 @@ public class FsSshFileSystemView extends FsFileSystemView<FsSshFile, SshFile> im
 
 	@Override
 	protected FsSshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), session, this);
+		return new FsSshFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), this, session);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
@@ -23,7 +23,7 @@ public class FsSshFileSystemView extends FsFileSystemView<FsSshFile, SshFile> im
 
 	@Override
 	protected FsSshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), this, session);
+		return new FsSshFile(file, pftpdService, this, session);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
@@ -1,5 +1,8 @@
 package org.primftpd.filesystem;
 
+import android.content.Context;
+import android.net.Uri;
+
 import java.io.File;
 
 import org.apache.sshd.common.file.SshFile;
@@ -12,15 +15,15 @@ public class FsSshFileSystemView extends FsFileSystemView<FsSshFile, SshFile> im
 	private final File homeDir;
 	private final Session session;
 
-	public FsSshFileSystemView(PftpdService pftpdService, File homeDir, Session session) {
-		super(pftpdService);
+	public FsSshFileSystemView(Context context, Uri safStartUrl, PftpdService pftpdService, File homeDir, Session session) {
+		super(context, safStartUrl, pftpdService);
 		this.homeDir = homeDir;
 		this.session = session;
 	}
 
 	@Override
 	protected FsSshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, session);
+		return new FsSshFile(file, pftpdService, getTimeResolution(file.getAbsolutePath()), session, this);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
@@ -21,6 +21,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
 
     private final ContentResolver contentResolver;
     protected final Uri startUrl;
+    protected final RoSafFileSystemView fileSystemView;
     protected final int timeResolution;
 
     private String documentId;
@@ -42,7 +43,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
             Uri startUrl,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution) {
+            RoSafFileSystemView fileSystemView) {
         // this c-tor is to be used for start directory
         super(
                 absPath,
@@ -56,7 +57,8 @@ public abstract class RoSafFile<T> extends AbstractFile {
         logger.trace("  c-tor 1");
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
-        this.timeResolution = timeResolution;
+        this.fileSystemView = fileSystemView;
+        this.timeResolution = fileSystemView.getTimeResolution();
 
         try {
             Cursor cursor = contentResolver.query(
@@ -89,7 +91,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
             String absPath,
             boolean exists,
             PftpdService pftpdService,
-            int timeResolution) {
+            RoSafFileSystemView fileSystemView) {
         // this c-tor is to be used for FileSystemView.getFile()
         super(
                 absPath,
@@ -103,7 +105,8 @@ public abstract class RoSafFile<T> extends AbstractFile {
         logger.trace("  c-tor 2");
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
-        this.timeResolution = timeResolution;
+        this.fileSystemView = fileSystemView;
+        this.timeResolution = fileSystemView.getTimeResolution();
 
         if (exists) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -136,7 +139,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution) {
+            RoSafFileSystemView fileSystemView) {
         // this c-tor is to be used by listFiles()
         super(
                 absPath,
@@ -150,7 +153,8 @@ public abstract class RoSafFile<T> extends AbstractFile {
         logger.trace("  c-tor 3");
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
-        this.timeResolution = timeResolution;
+        this.fileSystemView = fileSystemView;
+        this.timeResolution = fileSystemView.getTimeResolution();
         initByCursor(cursor);
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
@@ -157,8 +157,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
     private void initByCursor(Cursor cursor) {
         documentId = cursor.getString(0);
         name = cursor.getString(1);
-        int timeResolution = fileSystemView.getTimeResolution();
-        lastModified = (cursor.getLong(2) / timeResolution) * timeResolution;
+        lastModified = correctTime(this.fileSystemView, cursor.getLong(2));
         size = cursor.getLong(3);
 
         logger.trace("    initByCursor, doc id: {}, name: {}", documentId, name);
@@ -176,6 +175,11 @@ public abstract class RoSafFile<T> extends AbstractFile {
 
     private boolean flagPresent(int flags, int flag) {
         return ((flags & flag) == flag);
+    }
+
+    private static long correctTime(RoSafFileSystemView fileSystemView, long time) {
+        int timeResolution = fileSystemView.getTimeResolution();
+        return (time / timeResolution) * timeResolution;
     }
 
     protected abstract T createFile(

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
@@ -157,7 +157,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
     private void initByCursor(Cursor cursor) {
         documentId = cursor.getString(0);
         name = cursor.getString(1);
-        lastModified = correctTime(this.fileSystemView, cursor.getLong(2));
+        lastModified = fileSystemView.getCorrectedTime(cursor.getLong(2));
         size = cursor.getLong(3);
 
         logger.trace("    initByCursor, doc id: {}, name: {}", documentId, name);
@@ -175,11 +175,6 @@ public abstract class RoSafFile<T> extends AbstractFile {
 
     private boolean flagPresent(int flags, int flag) {
         return ((flags & flag) == flag);
-    }
-
-    private static long correctTime(RoSafFileSystemView fileSystemView, long time) {
-        int timeResolution = fileSystemView.getTimeResolution();
-        return (time / timeResolution) * timeResolution;
     }
 
     protected abstract T createFile(

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
@@ -21,6 +21,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
 
     private final ContentResolver contentResolver;
     protected final Uri startUrl;
+    protected final int timeResolution;
 
     private String documentId;
     private boolean writable;
@@ -40,7 +41,8 @@ public abstract class RoSafFile<T> extends AbstractFile {
             ContentResolver contentResolver,
             Uri startUrl,
             String absPath,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            int timeResolution) {
         // this c-tor is to be used for start directory
         super(
                 absPath,
@@ -54,6 +56,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
         logger.trace("  c-tor 1");
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
+        this.timeResolution = timeResolution;
 
         try {
             Cursor cursor = contentResolver.query(
@@ -85,7 +88,8 @@ public abstract class RoSafFile<T> extends AbstractFile {
             String docId,
             String absPath,
             boolean exists,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            int timeResolution) {
         // this c-tor is to be used for FileSystemView.getFile()
         super(
                 absPath,
@@ -99,6 +103,7 @@ public abstract class RoSafFile<T> extends AbstractFile {
         logger.trace("  c-tor 2");
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
+        this.timeResolution = timeResolution;
 
         if (exists) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -130,7 +135,8 @@ public abstract class RoSafFile<T> extends AbstractFile {
             Uri startUrl,
             Cursor cursor,
             String absPath,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            int timeResolution) {
         // this c-tor is to be used by listFiles()
         super(
                 absPath,
@@ -144,13 +150,14 @@ public abstract class RoSafFile<T> extends AbstractFile {
         logger.trace("  c-tor 3");
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
+        this.timeResolution = timeResolution;
         initByCursor(cursor);
     }
 
     private void initByCursor(Cursor cursor) {
         documentId = cursor.getString(0);
         name = cursor.getString(1);
-        lastModified = cursor.getLong(2);
+        lastModified = (cursor.getLong(2) / timeResolution) * timeResolution;
         size = cursor.getLong(3);
 
         logger.trace("    initByCursor, doc id: {}, name: {}", documentId, name);

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFile.java
@@ -22,7 +22,6 @@ public abstract class RoSafFile<T> extends AbstractFile {
     private final ContentResolver contentResolver;
     protected final Uri startUrl;
     protected final RoSafFileSystemView fileSystemView;
-    protected final int timeResolution;
 
     private String documentId;
     private boolean writable;
@@ -58,7 +57,6 @@ public abstract class RoSafFile<T> extends AbstractFile {
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
         this.fileSystemView = fileSystemView;
-        this.timeResolution = fileSystemView.getTimeResolution();
 
         try {
             Cursor cursor = contentResolver.query(
@@ -106,7 +104,6 @@ public abstract class RoSafFile<T> extends AbstractFile {
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
         this.fileSystemView = fileSystemView;
-        this.timeResolution = fileSystemView.getTimeResolution();
 
         if (exists) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -154,13 +151,13 @@ public abstract class RoSafFile<T> extends AbstractFile {
         this.contentResolver = contentResolver;
         this.startUrl = startUrl;
         this.fileSystemView = fileSystemView;
-        this.timeResolution = fileSystemView.getTimeResolution();
         initByCursor(cursor);
     }
 
     private void initByCursor(Cursor cursor) {
         documentId = cursor.getString(0);
         name = cursor.getString(1);
+        int timeResolution = fileSystemView.getTimeResolution();
         lastModified = (cursor.getLong(2) / timeResolution) * timeResolution;
         size = cursor.getLong(3);
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFileSystemView.java
@@ -49,8 +49,8 @@ public abstract class RoSafFileSystemView<T extends RoSafFile<X>, X> {
             String absPath,
             PftpdService pftpdService);
 
-    public int getTimeResolution() {
-        return timeResolution;
+    public long getCorrectedTime(long time) {
+        return (time / timeResolution) * timeResolution;
     }
 
     public T getFile(String file) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFileSystemView.java
@@ -49,6 +49,10 @@ public abstract class RoSafFileSystemView<T extends RoSafFile<X>, X> {
             String absPath,
             PftpdService pftpdService);
 
+    public int getTimeResolution() {
+        return timeResolution;
+    }
+
     public T getFile(String file) {
         logger.trace("getFile({}), startUrl: {}", file, startUrl);
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFileSystemView.java
@@ -20,11 +20,13 @@ public abstract class RoSafFileSystemView<T extends RoSafFile<X>, X> {
     protected final Uri startUrl;
     protected final ContentResolver contentResolver;
     protected final PftpdService pftpdService;
+    protected final int timeResolution;
 
     public RoSafFileSystemView(Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService) {
         this.startUrl = startUrl;
         this.contentResolver = contentResolver;
         this.pftpdService = pftpdService;
+        this.timeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(startUrl);
     }
 
     protected abstract String absolute(String file);

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
@@ -48,6 +48,10 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
         this.user = user;
     }
 
+    private RoSafFtpFileSystemView getFileSystemView() {
+        return (RoSafFtpFileSystemView)fileSystemView;
+    }
+
     @Override
     protected FtpFile createFile(
             ContentResolver contentResolver,
@@ -55,7 +59,7 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, cursor, absPath, pftpdService, (RoSafFtpFileSystemView)fileSystemView, user);
+        return new RoSafFtpFile(contentResolver, startUrl, cursor, absPath, pftpdService, getFileSystemView(), user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
@@ -17,8 +17,9 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             Uri startUrl,
             String absPath,
             PftpdService pftpdService,
+            int timeResolution,
             User user) {
-        super(contentResolver, startUrl, absPath, pftpdService);
+        super(contentResolver, startUrl, absPath, pftpdService, timeResolution);
         this.user = user;
     }
 
@@ -29,8 +30,9 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             String absPath,
             boolean exists,
             PftpdService pftpdService,
+            int timeResolution,
             User user) {
-        super(contentResolver, startUrl, docId, absPath, exists, pftpdService);
+        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, timeResolution);
         this.user = user;
     }
 
@@ -40,8 +42,9 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService,
+            int timeResolution,
             User user) {
-        super(contentResolver, startUrl, cursor, absPath, pftpdService);
+        super(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution);
         this.user = user;
     }
 
@@ -52,7 +55,7 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, cursor, absPath, pftpdService, user);
+        return new RoSafFtpFile(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
@@ -17,9 +17,9 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             Uri startUrl,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
+            RoSafFtpFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, startUrl, absPath, pftpdService, timeResolution);
+        super(contentResolver, startUrl, absPath, pftpdService, fileSystemView);
         this.user = user;
     }
 
@@ -30,9 +30,9 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             String absPath,
             boolean exists,
             PftpdService pftpdService,
-            int timeResolution,
+            RoSafFtpFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, timeResolution);
+        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, fileSystemView);
         this.user = user;
     }
 
@@ -42,9 +42,9 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
+            RoSafFtpFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution);
+        super(contentResolver, startUrl, cursor, absPath, pftpdService, fileSystemView);
         this.user = user;
     }
 
@@ -55,7 +55,7 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution, user);
+        return new RoSafFtpFile(contentResolver, startUrl, cursor, absPath, pftpdService, (RoSafFtpFileSystemView)fileSystemView, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
@@ -31,7 +31,7 @@ public class RoSafFtpFileSystemView extends RoSafFileSystemView<RoSafFtpFile, Ft
     }
 
     protected RoSafFtpFile createFileNonExistent(ContentResolver contentResolver, Uri startUrl, String name, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, name, absPath, false, pftpdService, user);
+        return new RoSafFtpFile(contentResolver, startUrl, name, absPath, false, pftpdService, this, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
@@ -22,12 +22,12 @@ public class RoSafFtpFileSystemView extends RoSafFileSystemView<RoSafFtpFile, Ft
 
     @Override
     protected RoSafFtpFile createFile(ContentResolver contentResolver, Uri startUrl, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, absPath, pftpdService, user);
+        return new RoSafFtpFile(contentResolver, startUrl, absPath, pftpdService, timeResolution, user);
     }
 
     @Override
     protected RoSafFtpFile createFile(ContentResolver contentResolver, Uri startUrl, String docId, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, docId, absPath, true, pftpdService, user);
+        return new RoSafFtpFile(contentResolver, startUrl, docId, absPath, true, pftpdService, timeResolution, user);
     }
 
     protected RoSafFtpFile createFileNonExistent(ContentResolver contentResolver, Uri startUrl, String name, String absPath, PftpdService pftpdService) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
@@ -22,12 +22,12 @@ public class RoSafFtpFileSystemView extends RoSafFileSystemView<RoSafFtpFile, Ft
 
     @Override
     protected RoSafFtpFile createFile(ContentResolver contentResolver, Uri startUrl, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, absPath, pftpdService, timeResolution, user);
+        return new RoSafFtpFile(contentResolver, startUrl, absPath, pftpdService, this, user);
     }
 
     @Override
     protected RoSafFtpFile createFile(ContentResolver contentResolver, Uri startUrl, String docId, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, docId, absPath, true, pftpdService, timeResolution, user);
+        return new RoSafFtpFile(contentResolver, startUrl, docId, absPath, true, pftpdService, this, user);
     }
 
     protected RoSafFtpFile createFileNonExistent(ContentResolver contentResolver, Uri startUrl, String name, String absPath, PftpdService pftpdService) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
@@ -19,8 +19,9 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             Uri startUrl,
             String absPath,
             PftpdService pftpdService,
+            int timeResolution,
             Session session) {
-        super(contentResolver, startUrl, absPath, pftpdService);
+        super(contentResolver, startUrl, absPath, pftpdService, timeResolution);
         this.session = session;
     }
 
@@ -31,8 +32,9 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             String absPath,
             boolean exists,
             PftpdService pftpdService,
+            int timeResolution,
             Session session) {
-        super(contentResolver, startUrl, docId, absPath, exists, pftpdService);
+        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, timeResolution);
         this.session = session;
     }
 
@@ -42,8 +44,9 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService,
+            int timeResolution,
             Session session) {
-        super(contentResolver, startUrl, cursor, absPath, pftpdService);
+        super(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution);
         this.session = session;
     }
 
@@ -54,7 +57,7 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, cursor, absPath, pftpdService, session);
+        return new RoSafSshFile(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
@@ -50,6 +50,10 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
         this.session = session;
     }
 
+    private RoSafSshFileSystemView getFileSystemView() {
+        return (RoSafSshFileSystemView)fileSystemView;
+    }
+
     @Override
     protected SshFile createFile(
             ContentResolver contentResolver,
@@ -57,7 +61,7 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, cursor, absPath, pftpdService, (RoSafSshFileSystemView)fileSystemView, session);
+        return new RoSafSshFile(contentResolver, startUrl, cursor, absPath, pftpdService, getFileSystemView(), session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
@@ -19,9 +19,9 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             Uri startUrl,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
+            RoSafSshFileSystemView fileSystemView,
             Session session) {
-        super(contentResolver, startUrl, absPath, pftpdService, timeResolution);
+        super(contentResolver, startUrl, absPath, pftpdService, fileSystemView);
         this.session = session;
     }
 
@@ -32,9 +32,9 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             String absPath,
             boolean exists,
             PftpdService pftpdService,
-            int timeResolution,
+            RoSafSshFileSystemView fileSystemView,
             Session session) {
-        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, timeResolution);
+        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, fileSystemView);
         this.session = session;
     }
 
@@ -44,9 +44,9 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
+            RoSafSshFileSystemView fileSystemView,
             Session session) {
-        super(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution);
+        super(contentResolver, startUrl, cursor, absPath, pftpdService, fileSystemView);
         this.session = session;
     }
 
@@ -57,7 +57,7 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
             Cursor cursor,
             String absPath,
             PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, cursor, absPath, pftpdService, timeResolution, session);
+        return new RoSafSshFile(contentResolver, startUrl, cursor, absPath, pftpdService, (RoSafSshFileSystemView)fileSystemView, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
@@ -19,12 +19,12 @@ public class RoSafSshFileSystemView extends RoSafFileSystemView<RoSafSshFile, Ss
 
     @Override
     protected RoSafSshFile createFile(ContentResolver contentResolver, Uri startUrl, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, absPath, pftpdService, timeResolution, session);
+        return new RoSafSshFile(contentResolver, startUrl, absPath, pftpdService, this, session);
     }
 
     @Override
     protected RoSafSshFile createFile(ContentResolver contentResolver, Uri startUrl, String docId, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, docId, absPath, true, pftpdService, timeResolution, session);
+        return new RoSafSshFile(contentResolver, startUrl, docId, absPath, true, pftpdService, this, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
@@ -29,7 +29,7 @@ public class RoSafSshFileSystemView extends RoSafFileSystemView<RoSafSshFile, Ss
 
     @Override
     protected RoSafSshFile createFileNonExistent(ContentResolver contentResolver, Uri startUrl, String name, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, name, absPath, false, pftpdService, session);
+        return new RoSafSshFile(contentResolver, startUrl, name, absPath, false, pftpdService, this, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
@@ -19,12 +19,12 @@ public class RoSafSshFileSystemView extends RoSafFileSystemView<RoSafSshFile, Ss
 
     @Override
     protected RoSafSshFile createFile(ContentResolver contentResolver, Uri startUrl, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, absPath, pftpdService, session);
+        return new RoSafSshFile(contentResolver, startUrl, absPath, pftpdService, timeResolution, session);
     }
 
     @Override
     protected RoSafSshFile createFile(ContentResolver contentResolver, Uri startUrl, String docId, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, docId, absPath, true, pftpdService, session);
+        return new RoSafSshFile(contentResolver, startUrl, docId, absPath, true, pftpdService, timeResolution, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -41,7 +41,6 @@ public abstract class SafFile<T> extends AbstractFile {
     private DocumentFile documentFile;
     private final DocumentFile parentDocumentFile;
     protected final SafFileSystemView fileSystemView;
-    protected final int timeResolution;
 
     private boolean writable;
 
@@ -69,11 +68,9 @@ public abstract class SafFile<T> extends AbstractFile {
         this.parentDocumentFile = parentDocumentFile;
         this.documentFile = documentFile;
         this.fileSystemView = fileSystemView;
-        this.timeResolution = fileSystemView.getTimeResolution();
 
-        if (timeResolution != 1) {
-            this.lastModified = (this.lastModified / timeResolution) * timeResolution;
-        }
+        int timeResolution = fileSystemView.getTimeResolution();
+        this.lastModified = (this.lastModified / timeResolution) * timeResolution;
 
         name = documentFile.getName();
         if (name == null && SafFileSystemView.ROOT_PATH.equals(absPath)) {
@@ -100,7 +97,6 @@ public abstract class SafFile<T> extends AbstractFile {
 
         this.parentDocumentFile = parentDocumentFile;
         this.fileSystemView = fileSystemView;
-        this.timeResolution = fileSystemView.getTimeResolution();
     }
 
     protected abstract T createFile(
@@ -139,6 +135,7 @@ public abstract class SafFile<T> extends AbstractFile {
             try {
                 Uri docUri = documentFile.getUri();
                 Path filePath = Paths.get(StorageManagerUtil.getFullDocIdPathFromTreeUri(docUri, pftpdService.getContext()));
+                int timeResolution = fileSystemView.getTimeResolution();
                 long convertedTime = (time / timeResolution) * timeResolution;
                 Files.getFileAttributeView(filePath, BasicFileAttributeView.class).setTimes(FileTime.fromMillis(convertedTime), null, null);
             } catch (Exception e) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -55,7 +55,7 @@ public abstract class SafFile<T> extends AbstractFile {
         super(
                 absPath,
                 null,
-                correctTime(fileSystemView, documentFile.lastModified()),
+                fileSystemView.getCorrectedTime(documentFile.lastModified()),
                 documentFile.length(),
                 documentFile.canRead(),
                 documentFile.exists(),
@@ -96,11 +96,6 @@ public abstract class SafFile<T> extends AbstractFile {
         this.fileSystemView = fileSystemView;
     }
 
-    private static long correctTime(SafFileSystemView fileSystemView, long time) {
-        int timeResolution = fileSystemView.getTimeResolution();
-        return (time / timeResolution) * timeResolution;
-    }
-
     protected abstract T createFile(
             ContentResolver contentResolver,
             DocumentFile parentDocumentFile,
@@ -137,7 +132,7 @@ public abstract class SafFile<T> extends AbstractFile {
             try {
                 Uri docUri = documentFile.getUri();
                 Path filePath = Paths.get(StorageManagerUtil.getFullDocIdPathFromTreeUri(docUri, pftpdService.getContext()));
-                long correctedTime = correctTime(fileSystemView, time);
+                long correctedTime = fileSystemView.getCorrectedTime(time);
                 Files.getFileAttributeView(filePath, BasicFileAttributeView.class).setTimes(FileTime.fromMillis(correctedTime), null, null);
                 return true;
             } catch (Exception e) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -55,7 +55,7 @@ public abstract class SafFile<T> extends AbstractFile {
         super(
                 absPath,
                 null,
-                documentFile.lastModified(),
+                (documentFile.lastModified() / timeResolution) * timeResolution,
                 documentFile.length(),
                 documentFile.canRead(),
                 documentFile.exists(),

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -40,6 +40,7 @@ public abstract class SafFile<T> extends AbstractFile {
 
     private DocumentFile documentFile;
     private final DocumentFile parentDocumentFile;
+    protected final SafFileSystemView fileSystemView;
     protected final int timeResolution;
 
     private boolean writable;
@@ -50,12 +51,12 @@ public abstract class SafFile<T> extends AbstractFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution) {
+            SafFileSystemView fileSystemView) {
         // this c-tor is to be used to access existing files
         super(
                 absPath,
                 null,
-                (documentFile.lastModified() / timeResolution) * timeResolution,
+                documentFile.lastModified(),
                 documentFile.length(),
                 documentFile.canRead(),
                 documentFile.exists(),
@@ -67,7 +68,12 @@ public abstract class SafFile<T> extends AbstractFile {
 
         this.parentDocumentFile = parentDocumentFile;
         this.documentFile = documentFile;
-        this.timeResolution = timeResolution;
+        this.fileSystemView = fileSystemView;
+        this.timeResolution = fileSystemView.getTimeResolution();
+
+        if (timeResolution != 1) {
+            this.lastModified = (this.lastModified / timeResolution) * timeResolution;
+        }
 
         name = documentFile.getName();
         if (name == null && SafFileSystemView.ROOT_PATH.equals(absPath)) {
@@ -82,7 +88,7 @@ public abstract class SafFile<T> extends AbstractFile {
             String name,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution) {
+            SafFileSystemView fileSystemView) {
         // this c-tor is to be used to upload new files, create directories or renaming
         super(absPath, name, 0, 0, false, false, false, pftpdService);
         String parentName = parentDocumentFile.getName();
@@ -93,7 +99,8 @@ public abstract class SafFile<T> extends AbstractFile {
         this.writable = true;
 
         this.parentDocumentFile = parentDocumentFile;
-        this.timeResolution = timeResolution;
+        this.fileSystemView = fileSystemView;
+        this.timeResolution = fileSystemView.getTimeResolution();
     }
 
     protected abstract T createFile(

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -246,7 +246,7 @@ public abstract class SafFile<T> extends AbstractFile {
         }
 
         if (documentFile != null) {
-            lastModified = documentFile.lastModified();
+            lastModified = fileSystemView.getCorrectedTime(documentFile.lastModified());
             size = 0;
             readable = documentFile.canRead();
             exists = true;

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -40,6 +40,7 @@ public abstract class SafFile<T> extends AbstractFile {
 
     private DocumentFile documentFile;
     private final DocumentFile parentDocumentFile;
+    protected final SafFileSystemView fileSystemView;
 
     private boolean writable;
 
@@ -48,7 +49,8 @@ public abstract class SafFile<T> extends AbstractFile {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
         // this c-tor is to be used to access existing files
         super(
                 absPath,
@@ -65,6 +67,7 @@ public abstract class SafFile<T> extends AbstractFile {
 
         this.parentDocumentFile = parentDocumentFile;
         this.documentFile = documentFile;
+        this.fileSystemView = fileSystemView;
 
         name = documentFile.getName();
         if (name == null && SafFileSystemView.ROOT_PATH.equals(absPath)) {
@@ -78,7 +81,8 @@ public abstract class SafFile<T> extends AbstractFile {
             DocumentFile parentDocumentFile,
             String name,
             String absPath,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
         // this c-tor is to be used to upload new files, create directories or renaming
         super(absPath, name, 0, 0, false, false, false, pftpdService);
         String parentName = parentDocumentFile.getName();
@@ -89,6 +93,7 @@ public abstract class SafFile<T> extends AbstractFile {
         this.writable = true;
 
         this.parentDocumentFile = parentDocumentFile;
+        this.fileSystemView = fileSystemView;
     }
 
     protected abstract T createFile(
@@ -96,7 +101,8 @@ public abstract class SafFile<T> extends AbstractFile {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService);
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView);
 
     @Override
     public ClientActionEvent.Storage getClientActionStorage() {
@@ -127,7 +133,9 @@ public abstract class SafFile<T> extends AbstractFile {
             try {
                 Uri docUri = documentFile.getUri();
                 Path filePath = Paths.get(StorageManagerUtil.getFullDocIdPathFromTreeUri(docUri, pftpdService.getContext()));
-                Files.getFileAttributeView(filePath, BasicFileAttributeView.class).setTimes(FileTime.fromMillis(time), null, null);
+                int timeResolution = fileSystemView.getTimeResolution();
+                long convertedTime = (time / timeResolution) * timeResolution;
+                Files.getFileAttributeView(filePath, BasicFileAttributeView.class).setTimes(FileTime.fromMillis(convertedTime), null, null);
             } catch (Exception e) {
                 String baseMsg = "could not set last modified time";
                 logger.error(baseMsg, e);
@@ -180,7 +188,7 @@ public abstract class SafFile<T> extends AbstractFile {
             String absPath = this.absPath.endsWith("/")
                     ? this.absPath + child.getName()
                     : this.absPath + "/" + child.getName();
-            result.add(createFile(contentResolver, documentFile, child, absPath, pftpdService));
+            result.add(createFile(contentResolver, documentFile, child, absPath, pftpdService, fileSystemView));
         }
         logger.trace("  [{}] listFiles(): num children: {}", name, Integer.valueOf(result.size()));
         return result;

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -40,7 +40,7 @@ public abstract class SafFile<T> extends AbstractFile {
 
     private DocumentFile documentFile;
     private final DocumentFile parentDocumentFile;
-    protected final SafFileSystemView fileSystemView;
+    protected final int timeResolution;
 
     private boolean writable;
 
@@ -50,7 +50,7 @@ public abstract class SafFile<T> extends AbstractFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
+            int timeResolution) {
         // this c-tor is to be used to access existing files
         super(
                 absPath,
@@ -67,7 +67,7 @@ public abstract class SafFile<T> extends AbstractFile {
 
         this.parentDocumentFile = parentDocumentFile;
         this.documentFile = documentFile;
-        this.fileSystemView = fileSystemView;
+        this.timeResolution = timeResolution;
 
         name = documentFile.getName();
         if (name == null && SafFileSystemView.ROOT_PATH.equals(absPath)) {
@@ -82,7 +82,7 @@ public abstract class SafFile<T> extends AbstractFile {
             String name,
             String absPath,
             PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
+            int timeResolution) {
         // this c-tor is to be used to upload new files, create directories or renaming
         super(absPath, name, 0, 0, false, false, false, pftpdService);
         String parentName = parentDocumentFile.getName();
@@ -93,7 +93,7 @@ public abstract class SafFile<T> extends AbstractFile {
         this.writable = true;
 
         this.parentDocumentFile = parentDocumentFile;
-        this.fileSystemView = fileSystemView;
+        this.timeResolution = timeResolution;
     }
 
     protected abstract T createFile(
@@ -101,8 +101,7 @@ public abstract class SafFile<T> extends AbstractFile {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView);
+            PftpdService pftpdService);
 
     @Override
     public ClientActionEvent.Storage getClientActionStorage() {
@@ -133,7 +132,6 @@ public abstract class SafFile<T> extends AbstractFile {
             try {
                 Uri docUri = documentFile.getUri();
                 Path filePath = Paths.get(StorageManagerUtil.getFullDocIdPathFromTreeUri(docUri, pftpdService.getContext()));
-                int timeResolution = fileSystemView.getTimeResolution();
                 long convertedTime = (time / timeResolution) * timeResolution;
                 Files.getFileAttributeView(filePath, BasicFileAttributeView.class).setTimes(FileTime.fromMillis(convertedTime), null, null);
             } catch (Exception e) {
@@ -188,7 +186,7 @@ public abstract class SafFile<T> extends AbstractFile {
             String absPath = this.absPath.endsWith("/")
                     ? this.absPath + child.getName()
                     : this.absPath + "/" + child.getName();
-            result.add(createFile(contentResolver, documentFile, child, absPath, pftpdService, fileSystemView));
+            result.add(createFile(contentResolver, documentFile, child, absPath, pftpdService));
         }
         logger.trace("  [{}] listFiles(): num children: {}", name, Integer.valueOf(result.size()));
         return result;

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
@@ -50,6 +50,10 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
 
     protected abstract String absolute(String file);
 
+    public int getTimeResolution() {
+        return timeResolution;
+    }
+
     public T getFile(String file) {
         logger.trace("getFile({}), startUrl: {}", file, startUrl);
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
@@ -50,8 +50,8 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
 
     protected abstract String absolute(String file);
 
-    public int getTimeResolution() {
-        return timeResolution;
+    public long getCorrectedTime(long time) {
+        return (time / timeResolution) * timeResolution;
     }
 
     public T getFile(String file) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
@@ -32,11 +32,7 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
         this.startUrl = startUrl;
         this.contentResolver = contentResolver;
         this.pftpdService = pftpdService;
-        timeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(startUrl);
-    }
-
-    protected int getTimeResolution() {
-        return timeResolution;
+        this.timeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(startUrl);
     }
 
     protected abstract T createFile(
@@ -44,15 +40,13 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView);
+            PftpdService pftpdService);
     protected abstract T createFile(
             ContentResolver contentResolver,
             DocumentFile parentDocumentFile,
             String name,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView);
+            PftpdService pftpdService);
 
     protected abstract String absolute(String file);
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
@@ -25,12 +25,18 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
     protected final Uri startUrl;
     protected final ContentResolver contentResolver;
     protected final PftpdService pftpdService;
+    protected final int timeResolution;
 
     public SafFileSystemView(Context context, Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService) {
         this.context = context;
         this.startUrl = startUrl;
         this.contentResolver = contentResolver;
         this.pftpdService = pftpdService;
+        timeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(startUrl);
+    }
+
+    protected int getTimeResolution() {
+        return timeResolution;
     }
 
     protected abstract T createFile(
@@ -38,13 +44,15 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService);
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView);
     protected abstract T createFile(
             ContentResolver contentResolver,
             DocumentFile parentDocumentFile,
             String name,
             String absPath,
-            PftpdService pftpdService);
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView);
 
     protected abstract String absolute(String file);
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
@@ -17,9 +17,9 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
+            SafFtpFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution);
+        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView);
         this.user = user;
     }
 
@@ -29,9 +29,9 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             String name,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
+            SafFtpFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution);
+        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView);
         this.user = user;
     }
 
@@ -42,7 +42,7 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService) {
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, (SafFtpFileSystemView)fileSystemView, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
@@ -17,8 +17,9 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
+            SafFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService);
+        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView);
         this.user = user;
     }
 
@@ -28,8 +29,9 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             String name,
             String absPath,
             PftpdService pftpdService,
+            SafFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, parentDocumentFile, name, absPath, pftpdService);
+        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView);
         this.user = user;
     }
 
@@ -39,8 +41,9 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, user);
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
+        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
@@ -35,6 +35,10 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
         this.user = user;
     }
 
+    private SafFtpFileSystemView getFileSystemView() {
+        return (SafFtpFileSystemView)fileSystemView;
+    }
+
     @Override
     protected FtpFile createFile(
             ContentResolver contentResolver,
@@ -42,7 +46,7 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService) {
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, (SafFtpFileSystemView)fileSystemView, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, getFileSystemView(), user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
@@ -17,9 +17,9 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
-            SafFileSystemView fileSystemView,
+            int timeResolution,
             User user) {
-        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView);
+        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution);
         this.user = user;
     }
 
@@ -29,9 +29,9 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             String name,
             String absPath,
             PftpdService pftpdService,
-            SafFileSystemView fileSystemView,
+            int timeResolution,
             User user) {
-        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView);
+        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution);
         this.user = user;
     }
 
@@ -41,9 +41,8 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, user);
+            PftpdService pftpdService) {
+        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
@@ -28,9 +28,10 @@ public class SafFtpFileSystemView extends SafFileSystemView<SafFtpFile, FtpFile>
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
         logger.trace("createFile(DocumentFile)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, user);
     }
 
     @Override
@@ -39,9 +40,10 @@ public class SafFtpFileSystemView extends SafFileSystemView<SafFtpFile, FtpFile>
             DocumentFile parentDocumentFile,
             String name,
             String absPath,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
         logger.trace("createFile(String)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
@@ -28,10 +28,9 @@ public class SafFtpFileSystemView extends SafFileSystemView<SafFtpFile, FtpFile>
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
+            PftpdService pftpdService) {
         logger.trace("createFile(DocumentFile)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, user);
     }
 
     @Override
@@ -40,10 +39,9 @@ public class SafFtpFileSystemView extends SafFileSystemView<SafFtpFile, FtpFile>
             DocumentFile parentDocumentFile,
             String name,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
+            PftpdService pftpdService) {
         logger.trace("createFile(String)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
@@ -30,7 +30,7 @@ public class SafFtpFileSystemView extends SafFileSystemView<SafFtpFile, FtpFile>
             String absPath,
             PftpdService pftpdService) {
         logger.trace("createFile(DocumentFile)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, this, user);
     }
 
     @Override
@@ -41,7 +41,7 @@ public class SafFtpFileSystemView extends SafFileSystemView<SafFtpFile, FtpFile>
             String absPath,
             PftpdService pftpdService) {
         logger.trace("createFile(String)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution, user);
+        return new SafFtpFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, this, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -38,6 +38,10 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
         this.session = session;
     }
 
+    private SafSshFileSystemView getFileSystemView() {
+        return (SafSshFileSystemView)fileSystemView;
+    }
+
     @Override
     protected SshFile createFile(
             ContentResolver contentResolver,
@@ -45,7 +49,7 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, (SafSshFileSystemView)fileSystemView, session);
+        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, getFileSystemView(), session);
     }
 
     @Override
@@ -83,7 +87,7 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             parentPath = "/";
         }
         logger.trace("[{}]   getParentFile() -> {}", name, parentPath);
-        return (SshFile)fileSystemView.getFile(parentPath);
+        return getFileSystemView().getFile(parentPath);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class SafSshFile extends SafFile<SshFile> implements SshFile {
 
     private final Session session;
+    private final SafSshFileSystemView fileSystemView;
 
     public SafSshFile(
             ContentResolver contentResolver,
@@ -20,10 +21,12 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
-            SafFileSystemView fileSystemView,
-            Session session) {
-        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView);
+            int timeResolution,
+            Session session,
+            SafSshFileSystemView fileSystemView) {
+        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution);
         this.session = session;
+        this.fileSystemView = fileSystemView;
     }
 
     public SafSshFile(
@@ -32,10 +35,12 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             String name,
             String absPath,
             PftpdService pftpdService,
-            SafFileSystemView fileSystemView,
-            Session session) {
-        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView);
+            int timeResolution,
+            Session session,
+            SafSshFileSystemView fileSystemView) {
+        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution);
         this.session = session;
+        this.fileSystemView = fileSystemView;
     }
 
     @Override
@@ -44,9 +49,8 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, session);
+            PftpdService pftpdService) {
+        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, session, fileSystemView);
     }
 
     @Override
@@ -84,7 +88,7 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             parentPath = "/";
         }
         logger.trace("[{}]   getParentFile() -> {}", name, parentPath);
-        return (SshFile)fileSystemView.getFile(parentPath);
+        return fileSystemView.getFile(parentPath);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -13,7 +13,6 @@ import java.util.List;
 public class SafSshFile extends SafFile<SshFile> implements SshFile {
 
     private final Session session;
-    private final SafSshFileSystemView fileSystemView;
 
     public SafSshFile(
             ContentResolver contentResolver,
@@ -21,12 +20,10 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
-            Session session,
-            SafSshFileSystemView fileSystemView) {
-        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution);
+            SafSshFileSystemView fileSystemView,
+            Session session) {
+        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView);
         this.session = session;
-        this.fileSystemView = fileSystemView;
     }
 
     public SafSshFile(
@@ -35,12 +32,10 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             String name,
             String absPath,
             PftpdService pftpdService,
-            int timeResolution,
-            Session session,
-            SafSshFileSystemView fileSystemView) {
-        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution);
+            SafSshFileSystemView fileSystemView,
+            Session session) {
+        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView);
         this.session = session;
-        this.fileSystemView = fileSystemView;
     }
 
     @Override
@@ -50,7 +45,7 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, session, fileSystemView);
+        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, (SafSshFileSystemView)fileSystemView, session);
     }
 
     @Override
@@ -88,7 +83,7 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             parentPath = "/";
         }
         logger.trace("[{}]   getParentFile() -> {}", name, parentPath);
-        return fileSystemView.getFile(parentPath);
+        return (SshFile)fileSystemView.getFile(parentPath);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -57,6 +57,18 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
     }
 
     @Override
+    public boolean setLastModified(long time) {
+        int timeResolution = fileSystemView.getTimeResolution();
+        long convertedTime;
+        if (timeResolution != 1000) { // in case of sftp, this is the finest resolution
+            convertedTime = (time / timeResolution) * timeResolution;
+        } else {
+            convertedTime = time;
+        }
+        return super.setLastModified(convertedTime);
+    }
+
+    @Override
     public boolean move(SshFile target) {
         logger.trace("move()");
         return super.move((SafFile)target);

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -13,7 +13,6 @@ import java.util.List;
 public class SafSshFile extends SafFile<SshFile> implements SshFile {
 
     private final Session session;
-    private final SafSshFileSystemView fileSystemView;
 
     public SafSshFile(
             ContentResolver contentResolver,
@@ -21,11 +20,10 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService,
-            Session session,
-            SafSshFileSystemView fileSystemView) {
-        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService);
+            SafFileSystemView fileSystemView,
+            Session session) {
+        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView);
         this.session = session;
-        this.fileSystemView = fileSystemView;
     }
 
     public SafSshFile(
@@ -34,11 +32,10 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             String name,
             String absPath,
             PftpdService pftpdService,
-            Session session,
-            SafSshFileSystemView fileSystemView) {
-        super(contentResolver, parentDocumentFile, name, absPath, pftpdService);
+            SafFileSystemView fileSystemView,
+            Session session) {
+        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView);
         this.session = session;
-        this.fileSystemView = fileSystemView;
     }
 
     @Override
@@ -47,25 +44,14 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, session, fileSystemView);
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
+        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, session);
     }
 
     @Override
     public String getClientIp() {
         return SshUtils.getClientIp(session);
-    }
-
-    @Override
-    public boolean setLastModified(long time) {
-        int timeResolution = fileSystemView.getTimeResolution();
-        long convertedTime;
-        if (timeResolution != 1000) { // in case of sftp, this is the finest resolution
-            convertedTime = (time / timeResolution) * timeResolution;
-        } else {
-            convertedTime = time;
-        }
-        return super.setLastModified(convertedTime);
     }
 
     @Override
@@ -98,7 +84,7 @@ public class SafSshFile extends SafFile<SshFile> implements SshFile {
             parentPath = "/";
         }
         logger.trace("[{}]   getParentFile() -> {}", name, parentPath);
-        return fileSystemView.getFile(parentPath);
+        return (SshFile)fileSystemView.getFile(parentPath);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
@@ -26,7 +26,7 @@ public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile>
             DocumentFile documentFile,
             String absPath,
             PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, session, this);
+        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, this, session);
     }
 
     @Override
@@ -36,7 +36,7 @@ public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile>
             String name,
             String absPath,
             PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution, session, this);
+        return new SafSshFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, this, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
@@ -20,19 +20,13 @@ public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile>
     }
 
     @Override
-    protected int getTimeResolution() {
-        return timeResolution > 1000 ? timeResolution : 1000; // sftp messages have 1s resolution
-    }
-    
-    @Override
     protected SafSshFile createFile(
             ContentResolver contentResolver,
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, session);
+            PftpdService pftpdService) {
+        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, timeResolution, session, this);
     }
 
     @Override
@@ -41,9 +35,8 @@ public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile>
             DocumentFile parentDocumentFile,
             String name,
             String absPath,
-            PftpdService pftpdService,
-            SafFileSystemView fileSystemView) {
-        return new SafSshFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView, session);
+            PftpdService pftpdService) {
+        return new SafSshFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, timeResolution, session, this);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
@@ -13,12 +13,18 @@ import org.primftpd.services.PftpdService;
 public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile> implements FileSystemView {
 
     private final Session session;
+    private final int timeResolution;
 
     public SafSshFileSystemView(Context context, Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService, Session session) {
         super(context, startUrl, contentResolver, pftpdService);
         this.session = session;
+        timeResolution = StorageManagerUtil.getFilesystemTimeResolutionForSftp(startUrl);
     }
 
+    protected int getTimeResolution() {
+        return timeResolution;
+    }
+    
     @Override
     protected SafSshFile createFile(
             ContentResolver contentResolver,

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
@@ -13,16 +13,15 @@ import org.primftpd.services.PftpdService;
 public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile> implements FileSystemView {
 
     private final Session session;
-    private final int timeResolution;
 
     public SafSshFileSystemView(Context context, Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService, Session session) {
         super(context, startUrl, contentResolver, pftpdService);
         this.session = session;
-        timeResolution = StorageManagerUtil.getFilesystemTimeResolutionForSftp(startUrl);
     }
 
+    @Override
     protected int getTimeResolution() {
-        return timeResolution;
+        return timeResolution > 1000 ? timeResolution : 1000; // sftp messages have 1s resolution
     }
     
     @Override
@@ -31,8 +30,9 @@ public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile>
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, session, this);
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
+        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView, session);
     }
 
     @Override
@@ -41,8 +41,9 @@ public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile>
             DocumentFile parentDocumentFile,
             String name,
             String absPath,
-            PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, session, this);
+            PftpdService pftpdService,
+            SafFileSystemView fileSystemView) {
+        return new SafSshFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/StorageManagerUtil.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/StorageManagerUtil.java
@@ -54,6 +54,20 @@ public final class StorageManagerUtil {
         }
     }
 
+    public static String getVolumePathFromTreeUri(@Nullable final Uri treeUri, Context context) {
+        if (treeUri == null) {
+            return null;
+        }
+        String volumePath = getVolumePath(getVolumeIdFromTreeUri(treeUri), context);
+        if (volumePath == null) {
+            return null;
+        }
+        if (! volumePath.endsWith(File.separator)) {
+            volumePath += File.separator;
+        }
+        return volumePath;
+    }
+
     /**
      * This function is to handle 2 Android bugs.
      * <p>

--- a/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
@@ -121,7 +121,12 @@ public class FtpServerService extends AbstractServerService
 				} else {
 					switch (prefsBean.getStorageType()) {
 						case PLAIN:
-							return new FsFtpFileSystemView(FtpServerService.this, prefsBean.getStartDir(), user);
+							return new FsFtpFileSystemView(
+									getApplicationContext(),
+									Uri.parse(prefsBean.getSafUrl()),
+									FtpServerService.this,
+									prefsBean.getStartDir(),
+									user);
 						case ROOT:
 							return new RootFtpFileSystemView(shell, FtpServerService.this, prefsBean.getStartDir(), user);
 						case SAF:
@@ -139,7 +144,12 @@ public class FtpServerService extends AbstractServerService
 									user);
 						case VIRTUAL:
 							return new VirtualFtpFileSystemView(
-									new FsFtpFileSystemView(FtpServerService.this, prefsBean.getStartDir(), user),
+									new FsFtpFileSystemView(
+											getApplicationContext(),
+											Uri.parse(prefsBean.getSafUrl()),
+											FtpServerService.this,
+											prefsBean.getStartDir(),
+											user),
 									new RootFtpFileSystemView(shell, FtpServerService.this, prefsBean.getStartDir(), user),
 									new SafFtpFileSystemView(
 											getApplicationContext(),

--- a/primitiveFTPd/src/org/primftpd/services/SshServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/SshServerService.java
@@ -206,7 +206,12 @@ public class SshServerService extends AbstractServerService
 				} else {
 					switch (prefsBean.getStorageType()) {
 						case PLAIN:
-							return new FsSshFileSystemView(SshServerService.this, prefsBean.getStartDir(), session);
+							return new FsSshFileSystemView(
+									getApplicationContext(),
+									Uri.parse(prefsBean.getSafUrl()),
+									SshServerService.this,
+									prefsBean.getStartDir(),
+									session);
 						case ROOT:
 							return new RootSshFileSystemView(shell, SshServerService.this, prefsBean.getStartDir(), session);
 						case SAF:
@@ -224,7 +229,12 @@ public class SshServerService extends AbstractServerService
 									session);
 						case VIRTUAL:
 							return new VirtualSshFileSystemView(
-									new FsSshFileSystemView(SshServerService.this, prefsBean.getStartDir(), session),
+									new FsSshFileSystemView(
+											getApplicationContext(),
+											Uri.parse(prefsBean.getSafUrl()),
+											SshServerService.this,
+											prefsBean.getStartDir(),
+											session),
 									new RootSshFileSystemView(shell, SshServerService.this, prefsBean.getStartDir(), session),
 									new SafSshFileSystemView(
 											getApplicationContext(),


### PR DESCRIPTION
As I wrote in https://github.com/wolpi/prim-ftpd/pull/351#issuecomment-2158001529, Android lies about the lastModifiedTime. Even the specs says, that if the time resolution is lower than what we ask, the next getLastModifiedTime will give back the "truncated" value, this is simply not true (tested on real phone, Android 9.0 and emulator). It gives back the truncated values only when he wants, usually hours later. This is an unpredictable nightmare.

This fix:
- adds a new method to the `StorageManagerUtil` class that detects SAF filesystems from `/proc/mounts`, it detects:
  - FAT16, FAT32 -> 2000ms
  - exFAT -> ~10ms~ 2000ms
  - default 1ms
- moves the `fileSystemView` property from `SafSshFile` up to `SafFile`, so all SAF file can call the new `getTimeResolution()` from `SafFileSystemView`

Update:
- also implemented for roSAF and poFS
- poFS alters mtime only for files on the SD card's, ie. under path eg. /storage/XXXX-XXXX

~Maybe the default 1ms is overkill, in theory FTP has sub-second resolution, though we can modify StorageManagerUtil to return only 1000 vs 2000 ms, in this case no overload needed in `SafSshFileSystemView` to limit sub second resolution to the 1s resolution of sftp messages.~
