### PR TITLE
Reenable '[' and ']' chars on SAF

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -30,8 +30,6 @@ public abstract class SafFile<T> extends AbstractFile {
     private final static Set<String> KNOWN_BAD_CHARS;
     static {
         Set<String> tmp = new HashSet<>();
-        tmp.add("[");
-        tmp.add("]");
         tmp.add("*");
         tmp.add("?");
         tmp.add("\\");


### PR DESCRIPTION
The fix for issue #337 introduced a complete ban on these chars.

Meanwhile they are working fine on most systems. I've tested it with: Android 9.0, 32GB SD card with FAT32, 64GB SD card with exFAT, WinSCP, Python Paramiko. Copied small and large (360MB) files with `[]` in their names, after upload and download the SHA1 hashes are not changed.

So the root cause of #337 is not something general that requires a complete ban on these chars. Maybe that is a niche Andorid bug (though until locating the root cause, it is hard to provide even a workaround for it), or a concrete config's or hardware's issue.