### PR TITLE
Speed up SAF 100x

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
@@ -78,8 +78,7 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
                             childrenUri,
                             new String[] {
                                     DocumentsContract.Document.COLUMN_DOCUMENT_ID,
-                                    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
-                                    DocumentsContract.Document.COLUMN_MIME_TYPE
+                                    DocumentsContract.Document.COLUMN_DISPLAY_NAME
                             },
                             null,
                             null,
@@ -88,19 +87,13 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
                         while (childCursor.moveToNext()) {
                             String docId = childCursor.getString(0);
                             String docName = childCursor.getString(1);
-                            String docMimeType = childCursor.getString(2);
                             if (currentPart.equals(docName)) {
                                 if (i == parts.size() - 1) {
                                     Uri docUri = DocumentsContract.buildDocumentUriUsingTree(startUrl, docId);
                                     Uri parentUri = DocumentsContract.buildDocumentUriUsingTree(startUrl, parentId);
                                     logger.trace("    calling createFile() for doc: {}, docId: {}, docUri: {}, parentId: {}, parentUri: {}", new Object[]{currentPart, docId, docUri, parentId, parentUri});
                                     DocumentFile parentDocFile = DocumentFile.fromTreeUri(context, parentUri);
-                                    DocumentFile docFile = null;
-                                    if (docMimeType.equals(DocumentsContract.Document.MIME_TYPE_DIR)) {
-                                        docFile = DocumentFile.fromTreeUri(context, docUri);
-                                    } else {
-                                        docFile = DocumentFile.fromSingleUri(context, docUri);
-                                    }
+                                    DocumentFile docFile = DocumentFile.fromTreeUri(context, docUri);
                                     String absPath = Utils.toPath(parts);
                                     return createFile(contentResolver, parentDocFile, docFile, absPath, pftpdService);
                                 } else {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
@@ -124,7 +124,6 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
                                 logger.error("path does not exist: {}", absPath);
                                 // fall through to returning the root document
                                 break;
-
                             }
                         }
                     } finally {

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFileSystemView.java
@@ -2,8 +2,11 @@ package org.primftpd.filesystem;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
+import android.provider.DocumentsContract;
 import androidx.documentfile.provider.DocumentFile;
 import android.widget.Toast;
 
@@ -46,36 +49,91 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
     protected abstract String absolute(String file);
 
     public T getFile(String file) {
-        logger.trace("getFile({})", file);
+        logger.trace("getFile({}), startUrl: {}", file, startUrl);
 
         String abs = absolute(file);
         logger.trace("  getFile(abs: {})", abs);
 
         try {
-            List<String> parts = Utils.normalizePath(abs);
-            logger.trace("  getFile(): normalized path parts: '{}'", parts);
-            DocumentFile rootDocFile = DocumentFile.fromTreeUri(context, startUrl);
-            DocumentFile docFile = rootDocFile;
-            for (int i=0; i<parts.size(); i++) {
-                String currentPart = parts.get(i);
-                logger.trace("  getFile(): current docFile '{}', current part: '{}'", docFile.getName(), currentPart);
-                DocumentFile parentDocFile = docFile;
-                docFile = docFile.findFile(currentPart);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                    && !ROOT_PATH.equals(abs)) {
+                String parentId = DocumentsContract.getTreeDocumentId(startUrl);
 
-                if (docFile != null) {
-                    boolean found = i == parts.size() - 1;
-                    String absPath = Utils.toPath(parts);
-                    T child = createFile(contentResolver, parentDocFile, docFile, absPath, pftpdService);
-                    if (found) {
-                        return child;
+                List<String> parts = Utils.normalizePath(abs);
+                logger.trace("    getFile(normalized: {})", parts);
+
+                for (int i=0; i<parts.size(); i++) {
+                    String currentPart = parts.get(i);
+
+                    logger.trace("    building children uri for parent: {}", parentId);
+                    Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(
+                            startUrl,
+                            parentId);
+                    // Never ever use DocumentFile.findFile(), it uses DocumentFile.listFile(), that queries the whole directory for IDs,
+                    // then queries FOR EACH FILE AGAIN for the name, then findFile() selects from this name list. Unbelievable.
+                    // See: https://www.reddit.com/r/androiddev/comments/bbejc4/caveats_with_documentfile/
+                    // Do not use selection and selectionArgs for ContentResolver.query(), Android doesn't care, it will return all the files whatever you do.
+                    // See: https://stackoverflow.com/a/61214849
+                    Cursor childCursor = contentResolver.query(
+                            childrenUri,
+                            new String[] {
+                                    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                                    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                                    DocumentsContract.Document.COLUMN_MIME_TYPE
+                            },
+                            null,
+                            null,
+                            null);
+                    try {
+                        while (childCursor.moveToNext()) {
+                            String docId = childCursor.getString(0);
+                            String docName = childCursor.getString(1);
+                            String docMimeType = childCursor.getString(2);
+                            if (currentPart.equals(docName)) {
+                                if (i == parts.size() - 1) {
+                                    Uri docUri = DocumentsContract.buildDocumentUriUsingTree(startUrl, docId);
+                                    Uri parentUri = DocumentsContract.buildDocumentUriUsingTree(startUrl, parentId);
+                                    logger.trace("    calling createFile() for doc: {}, docId: {}, docUri: {}, parentId: {}, parentUri: {}", new Object[]{currentPart, docId, docUri, parentId, parentUri});
+                                    DocumentFile parentDocFile = DocumentFile.fromTreeUri(context, parentUri);
+                                    DocumentFile docFile = null;
+                                    if (docMimeType.equals(DocumentsContract.Document.MIME_TYPE_DIR)) {
+                                        docFile = DocumentFile.fromTreeUri(context, docUri);
+                                    } else {
+                                        docFile = DocumentFile.fromSingleUri(context, docUri);
+                                    }
+                                    String absPath = Utils.toPath(parts);
+                                    return createFile(contentResolver, parentDocFile, docFile, absPath, pftpdService);
+                                } else {
+                                    parentId = docId;
+                                    break;
+                                }
+                            }
+                        }
+                        if (childCursor.isAfterLast()) {
+                            // not found
+                            if (i == parts.size() - 1) {
+                                // probably upload -> create object just with name
+                                Uri parentUri = DocumentsContract.buildDocumentUriUsingTree(startUrl, parentId);
+                                logger.trace("    calling createFile() for doc: {}, parentId: {}, parentUri: {}", new Object[]{currentPart, parentId, parentUri});
+                                DocumentFile parentDocFile = DocumentFile.fromTreeUri(context, parentUri);
+                                String absPath = Utils.toPath(parts);
+                                return createFile(contentResolver, parentDocFile, currentPart, absPath, pftpdService);
+                            } else {
+                                // invalid path
+                                String absPath = Utils.toPath(parts.subList(0, i+1));
+                                logger.error("path does not exist: {}", absPath);
+                                // fall through to returning the root document
+                                break;
+
+                            }
+                        }
+                    } finally {
+                        closeQuietly(childCursor);
                     }
-                } else {
-                    // probably upload -> create object just with name
-                    String absPath = Utils.toPath(parts);
-                    return createFile(contentResolver, parentDocFile, currentPart, absPath, pftpdService);
                 }
             }
-
+            DocumentFile rootDocFile = DocumentFile.fromTreeUri(context, startUrl);
+            logger.trace("    calling createFile() for root doc: {}", startUrl);
             return createFile(contentResolver, rootDocFile, rootDocFile, ROOT_PATH, pftpdService);
         } catch (Exception e) {
             final String msg = "[(s)ftpd] Error getting data from SAF: " + e.toString();
@@ -88,6 +146,12 @@ public abstract class SafFileSystemView<T extends SafFile<X>, X> {
                 }
             });
             throw e;
+        }
+    }
+
+    private void closeQuietly(Cursor cursor) {
+        if (cursor != null) {
+            cursor.close();
         }
     }
 }


### PR DESCRIPTION
Summary:
- When there are 1000s of files in a dir, even opening a file takes **several minutes**!!!
- The root cause is that creating even 1 SafFile involves a call to DocumentFile.findFile() and it calls listFiles(), and that is extremely slow on a big dir.
- I've copied the Cursor code from RoSafFileSystemView.getFile() (with some minor improvements).
- Now opening a file is a **fraction of a second** on a dir with 1000s of files!!!
- Though listing a dir is still slow, it uses listFiles(), and we can't do anything about it.

One issue with the code below:
- When there is an invalid path, like `/valid-folder/nonexistent-folder/nonexistent-folder/file.xxx`, what should we do with `nonexistent-folder`s???
- We should throw an Exception, but this is not allowed here, we can't return null, it will harm SftpSubsystem.
- Original code returned a SafFile referencing  `/valid-folder/invalid-folder` and finally a file was created with the name of `invalid-folder`, still not a good outcome. And without any error message.

**UPDATE: this PR can remain as is, this issue will be fixed in a new PR, because it got quite complex**

~Possible better solutions:~
~- Extend FileSystemView.getFile() with a `throws Exception` and modify SftpSubsystem's code? I remember you don't like modifying the original server's code.~
~- Create some dummy "fails on everything" SafFile+SafFtpFile+SafSshFile, and that will throw the proper FileNotFoundException on the first call? Maybe this is the most analog to what would happen on a real file-system with File. But it smells like an ugly hack.~
~- Any idea???~