### PR TITLE
SAF: disable move when renaming

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -161,7 +161,7 @@ public abstract class SafFile<T> extends AbstractFile {
 
     public boolean move(SafFile<T> destination) {
         logger.trace("[{}] move({})", name, destination.getAbsolutePath());
-        if (writable && documentFile != null) {
+        if (writable && documentFile != null && Utils.parent(this.absPath).equals(Utils.parent(destination.getAbsolutePath()))) {
             postClientAction(ClientActionEvent.ClientAction.RENAME);
             return documentFile.renameTo(destination.getName());
         }


### PR DESCRIPTION
fixes #368

DocumentFile.renameTo() can change only the display-name, this PR returns false if the destination and source paths are different.

Note: With read-write-ROSAF it would be possible, DocumentsContract has a moveDocument() method.