### PR TITLE
Add hidden readonly virtual config file to virtFS

### DIFF
--- a/primitiveFTPd/src/org/primftpd/events/ClientActionEvent.java
+++ b/primitiveFTPd/src/org/primftpd/events/ClientActionEvent.java
@@ -10,7 +10,8 @@ public class ClientActionEvent {
         ROOT,
         SAF,
         ROSAF,
-        QUICKSHARE
+        QUICKSHARE,
+        CONFIG
     }
 
     public enum Protocol {

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualConfigFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualConfigFile.java
@@ -1,0 +1,82 @@
+package org.primftpd.filesystem;
+
+import org.primftpd.events.ClientActionEvent;
+import org.primftpd.services.PftpdService;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+public abstract class VirtualConfigFile extends AbstractFile {
+
+    public static final String NAME = "primftpd.config";
+    public static final String ABS_PATH = "/" + NAME;
+
+    private String content;
+
+    public VirtualConfigFile(
+            PftpdService pftpdService) {
+        super(
+                ABS_PATH,
+                NAME,
+                0,
+                0,
+                true,
+                true,
+                false,
+                pftpdService);
+        this.content = getContent();
+        size = content.length();
+    }
+
+    private String getContent() {
+        return
+            "{" +
+                "\"announceName\":\"" + pftpdService.getPrefsBean().getAnnounceName().replaceAll("\"", "\\\"") + "\"" +
+            "}";
+    }
+
+    public ClientActionEvent.Storage getClientActionStorage() {
+        return ClientActionEvent.Storage.CONFIG;
+    }
+
+    public boolean isFile() {
+        return true;
+    }
+
+    public boolean isWritable() {
+        return false;
+    }
+
+    public boolean isRemovable() {
+        return false;
+    }
+
+    public boolean setLastModified(long time) {
+        return false;
+    }
+
+    public boolean mkdir() {
+        return false;
+    }
+
+    public boolean delete() {
+        return false;
+    }
+
+    public OutputStream createOutputStream(long offset) throws IOException {
+        return null;
+    }
+
+    public InputStream createInputStream(long offset) throws IOException {
+        logger.trace("[{}] createInputStream(offset: {})", name, offset);
+        postClientAction(ClientActionEvent.ClientAction.DOWNLOAD);
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        bais.skip(offset);
+        return bais;
+    }
+
+}

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualConfigFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualConfigFile.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+// For more details see https://github.com/wolpi/prim-ftpd/pull/378
 public abstract class VirtualConfigFile extends AbstractFile {
 
     public static final String NAME = "primftpd.config";

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualConfigFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualConfigFile.java
@@ -34,7 +34,7 @@ public abstract class VirtualConfigFile extends AbstractFile {
     private String getContent() {
         return
             "{" +
-                "\"announceName\":\"" + pftpdService.getPrefsBean().getAnnounceName().replaceAll("\"", "\\\"") + "\"" +
+                "\"announceName\":\"" + pftpdService.getPrefsBean().getAnnounceName().replace("\"", "\\\"") + "\"" +
             "}";
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
@@ -41,6 +41,8 @@ public abstract class VirtualFileSystemView<
     public abstract MinaType createFile(String absPath, AbstractFile delegate, PftpdService pftpdService);
     public abstract MinaType createFile(String absPath, AbstractFile delegate, boolean exists, PftpdService pftpdService);
 
+    public abstract AbstractFile getConfigFile();
+
     protected abstract String absolute(String file);
 
     public MinaType getFile(String file) {
@@ -68,7 +70,11 @@ public abstract class VirtualFileSystemView<
             logger.debug("Using ROSAF '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = roSafFileSystemView.getFile(realPath);
             return createFile(absoluteVirtualPath, delegate, pftpdService);
-        } else {
+        } else if (VirtualConfigFile.ABS_PATH.equals(absoluteVirtualPath)) {
+            logger.debug("Using VirtualFile for CONFIG path '{}'", absoluteVirtualPath);
+            AbstractFile delegate = getConfigFile();
+            return createFile(absoluteVirtualPath, delegate, pftpdService);
+        } else{
             logger.debug("Using VirtualFile for unknown path '{}'", absoluteVirtualPath);
             return createFile(absoluteVirtualPath, null, false, pftpdService);
         }

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpConfigFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpConfigFile.java
@@ -1,0 +1,19 @@
+package org.primftpd.filesystem;
+
+import org.apache.ftpserver.ftplet.User;
+import org.primftpd.services.PftpdService;
+
+public class VirtualFtpConfigFile extends VirtualConfigFile {
+
+    private final User user;
+
+    public VirtualFtpConfigFile(PftpdService pftpdService, User user) {
+        super(pftpdService);
+        this.user = user;
+    }
+
+    @Override
+    public String getClientIp() {
+        return FtpUtils.getClientIp(user);
+    }
+}

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
@@ -43,6 +43,11 @@ public class VirtualFtpFileSystemView extends VirtualFileSystemView<
     }
 
     @Override
+    public AbstractFile getConfigFile() {
+        return new VirtualFtpConfigFile(pftpdService, user);
+    }
+
+    @Override
     protected String absolute(String file) {
         logger.trace("  finding abs path for '{}' with wd '{}'", file, (workingDir != null ? workingDir.getAbsolutePath() : "null"));
         if (workingDir == null) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshConfigFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshConfigFile.java
@@ -1,0 +1,19 @@
+package org.primftpd.filesystem;
+
+import org.apache.sshd.common.Session;
+import org.primftpd.services.PftpdService;
+
+public class VirtualSshConfigFile extends VirtualConfigFile {
+
+    private final Session session;
+
+    public VirtualSshConfigFile(PftpdService pftpdService, Session session) {
+        super(pftpdService);
+        this.session = session;
+    }
+
+    @Override
+    public String getClientIp() {
+        return SshUtils.getClientIp(session);
+    }
+}

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
@@ -41,6 +41,11 @@ public class VirtualSshFileSystemView extends VirtualFileSystemView<
     }
 
     @Override
+    public AbstractFile getConfigFile() {
+        return new VirtualSshConfigFile(pftpdService, session);
+    }
+
+    @Override
     protected String absolute(String file) {
         return Utils.absoluteOrHome(file, "/" + PREFIX_FS + homeDir.getAbsolutePath());
     }


### PR DESCRIPTION
What it does:
- Adds a virtual read-only `/primftpd.config` text file to the virtual file-system
- File is not listed in the `/` folder (ie. hidden)
- File contains some config values as JSON, curently only: `{"announceName":"<DNS_SD_SERVICE_NAME>"}`

Why:
- Android doesn't reply DSN-SD queries when the screen is off (even when we connect to the pftpd server)
- Though Android announces the new service, when the pftpd server starts up
- SFTP clients can capture and cache the announcement to connect to a phone through zeroconf even when the screen is off

Problem:
- Cached value can become invalid (IP address change), but another phone with the same config (another phone in the family) can receive the same IP
- In this case we connect to a different phone, and if we start a bidirectional sync, it will cause serious problems... imagine the 2 different Camera folders...

Solution:
- The only thing I could figure out is to read at least this config value like we read general unix config values, ie. through the file-system
- Currently this virtual file is added only to the virtFS, because only my sync script uses this, and that script is usefull mainly with virtFS (reading through plain old FS, writing SAF)
- If you think it can be generally useful, I can add this to plain-old-FS, SAF and ROSAF later

---

Yes, I know, you wana see that sync script. 😄 Here it is (this got split into 3 projects, altogether ~2500 lines of Python, the last 1% functionality took the last 99% of time... the non-stable/unfinished parts are removed, and I've stolen the "primitive" brand):
- https://pypi.org/project/prim-sync/ The sync stuff
- https://pypi.org/project/prim-ctrl/ The remote control (start/stop) stuff
- https://pypi.org/project/prim-batch/ The batch execution (multiple phones, multiple folders) stuff

The simplest way to test, is to install my forked pftpd from https://github.com/lmagyar/prim-ftpd (this is another app, so you have to configure it also), then:
- `pipx install prim-sync`
- `pipx install prim-ctrl`
- `pipx install prim-batch`

Currently it runs scheduled in my family, phones unattended, a sync over ~100 folders and 1000s of files takes less then a minute.

Runs live on Windows 11, but also smoke tested on Ubuntu.