### PR TITLE
fix(ui): tabs squeezed when displaying tab titles

### DIFF
--- a/primitiveFTPd/res/layout/tabs_activity.xml
+++ b/primitiveFTPd/res/layout/tabs_activity.xml
@@ -19,7 +19,7 @@
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"/>
     </com.google.android.material.appbar.AppBarLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
+++ b/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
@@ -100,6 +100,8 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
         adapter.clearTitles();
         adapter.addTitle("pftpd");
         adapter.addTitle("QR");
+
+        TabLayout tabLayout = findViewById(R.id.tabs);
         if (tabNames) {
             adapter.addTitle("\uD83D\uDDD1 " + getText(R.string.iconCleanSpace));
             adapter.addTitle("\uD83D\uDDD2 " + getText(R.string.clientActionsLabel));
@@ -107,6 +109,8 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
             adapter.addTitle("\uD83D\uDD10 " + getText(R.string.pubkeyAuthKeysHeading));
             adapter.addTitle("⚙ " + getText(R.string.prefs));
             adapter.addTitle("\uD83D\uDE4F " + getText(R.string.iconAbout));
+
+            tabLayout.setTabMode(TabLayout.MODE_SCROLLABLE);
         } else {
             adapter.addTitle("\uD83D\uDDD1");
             adapter.addTitle("\uD83D\uDDD2");
@@ -114,6 +118,8 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
             adapter.addTitle("\uD83D\uDD10");
             adapter.addTitle("⚙");
             adapter.addTitle("\uD83D\uDE4F");
+
+            tabLayout.setTabMode(TabLayout.MODE_FIXED);
         }
         adapter.notifyDataSetChanged();
     }


### PR DESCRIPTION
This fixes a problem with the UI where the tabs are squeezed and the titles are not legible when displaying tab titles. Fixed in the Java code so that when titles are not displayed, all the tabs are displayed in the available page width.

![tabs_fixed](https://github.com/user-attachments/assets/f73e856b-ee68-43e9-82e1-dc81a27a2ac8)
![tabs-icons](https://github.com/user-attachments/assets/c833df4c-8d34-4f4c-aa5f-9f81867b4e5a)
