### PR TITLE
fix(#380): Address repeated when reopening QR tab

### DIFF
--- a/primitiveFTPd/src/org/primftpd/ui/QrFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/QrFragment.java
@@ -128,6 +128,7 @@ public class QrFragment extends Fragment implements RecreateLogger {
                 fragment.qrImage.setImageBitmap(qr);
             });
         }
+        urlsParent.removeAllViewsInLayout();
         urlsParent.addView(radioGroup);
         if (!urls.isEmpty()) {
             View firstRadio = radioGroup.getChildAt(0);


### PR DESCRIPTION
This fixes #380. The LinearLayout containing the radio groups is now cleared before adding new children.