### PR TITLE
Add /sdcard to the possible injected poFS dir list (just extend a comment, no functional change

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -29,7 +29,7 @@ public abstract class FsFile<T> extends AbstractFile {
 	static {
 		Map<String, String[]> tmp = new HashMap<>();
 		// more known directories might be added
-		//tmp.put("/", new String[] {"dev", "etc", "mnt", "proc", "product", "storage", "system", "vendor"});
+		//tmp.put("/", new String[] {"dev", "etc", "mnt", "proc", "product", "sdcard", "storage", "system", "vendor"});
 		tmp.put("/", new String[] {"storage"});
 		tmp.put("/storage/emulated", new String[] {"0"});
 		DIRECTORY_INJECTIONS = Collections.unmodifiableMap(tmp);


### PR DESCRIPTION
I saw in #205 that there are users who access the internal storage this way, not through /storage/emulated/0.

Maybe it will be handy in the future.