### PR TITLE
fix(#365): FTP Server not reachable until app restart

### DIFF
--- a/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
+++ b/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
@@ -218,7 +218,7 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
     public void handleStart() {
         logger.trace("handleStart()");
 
-        ServicesStartStopUtil.startServers(pftpdFragment);
+        ServicesStartStopUtil.startServers(this);
     }
 
     protected void handleStop() {


### PR DESCRIPTION
The context sent to ServicesStartStopUtil.startServers() seem to be old. The preferences taken from this context do not seem to be updated. The fix was to send the Activity context to the start function.