### PR TITLE
Add ENGLISH title and short/long descriptions to metadata folder

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,5 @@
+A simple FTP and SFTP (SSH file transfer) server. Allows to exchange files with
+other machines over WiFi. No more USB cable searching. Runs without root
+privileges and is not started when device boots: Control yourself when the
+server runs. However, while it runs it prevents standby to avoid long uploads
+and downloads to abort.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+FTP server

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Primitive FTPd


### PR DESCRIPTION
Fixes #390 .

Descriptions were copied from the F-Droid's repositories [data](https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/org.primftpd.yml#L8) and [data-localizations](https://gitlab.com/fdroid/fdroiddata-localizations/-/blob/master/localizations/ca.xliff#L7608).

1. Only the `short_summary.txt` can be translated in [Weblate](https://hosted.weblate.org/translate/f-droid/fdroiddata/ca/?checksum=0d90aae9db152fdb&q=ftpd&sort_by=-priority%2Cposition#translations).
2. The `full_description.txt` cannot be translated in Weblate; hence the impossibility to show it translated to users on your app's page in F-Droid and Google Play, as stated in #390 .

# Notes
From [F-Droid's page about metadata](https://f-droid.org/en/docs/All_About_Descriptions_Graphics_and_Screenshots/).
> Please be aware that texts in the app’s metadata file will override all other descriptive texts provided through the structures explained below. This affects [Name](https://f-droid.org/en/docs/Build_Metadata_Reference/#Name), [Summary](https://f-droid.org/en/docs/Build_Metadata_Reference/#Summary), and [Description](https://f-droid.org/en/docs/Build_Metadata_Reference/#Description). Once metadata fields that were previously in the metadata file have been moved to the app’s source repo, please file a [merge request](https://gitlab.com/fdroid/fdroiddata/merge_requests) or [issue](https://gitlab.com/fdroid/fdroiddata/issues) to remove Summary and Description from the app’s metadata file.

1. Changes in this PR, and their future PR translations, will **not be visible for the users** until you demand F-Droid explicitly to remove the short and long descriptions from their repositories (linked in first paragraph).
2. Before doing so, you should **retrieve and save** the already existing translations of the short summary: the ones in Weblate. They can be easily copied directly from the Weblate link I provided above, from the tab "Other languages".
3. For those languages that have a short summary translation (point 2), you should provide the full description in English; since short and full description files are **mandatory for F-Droid**.