### PR TITLE
Fix test regex

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -141,7 +141,7 @@ def check(value, text, errors, msg):
 def checkExp(exp, text, errors, msg):
     found = False
     if type(text) is str:
-        matchobject = re.match(exp, text)
+        matchobject = re.match(exp, text, re.DOTALL)
         if not matchobject is None:
             found = True
     if not found == True:


### PR DESCRIPTION
Running tests on Ubuntu (OK, on WSL2 and running server in Windows/Android Studio) this is needed.

When we search in multiline responses, without this it can't find the correct response in the 2nd line because of the LF character.
