### PR TITLE
File-system refactor - plus minor bugfixes

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/AbstractFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/AbstractFileSystemView.java
@@ -1,0 +1,20 @@
+package org.primftpd.filesystem;
+
+import org.primftpd.services.PftpdService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractFileSystemView {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    protected final PftpdService pftpdService;
+
+    public AbstractFileSystemView(PftpdService pftpdService) {
+        this.pftpdService = pftpdService;
+    }
+
+    public final PftpdService getPftpdService() {
+        return pftpdService;
+    }
+}

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFile.java
@@ -6,16 +6,12 @@ import org.apache.ftpserver.ftplet.FtpFile;
 import org.apache.ftpserver.ftplet.User;
 import org.primftpd.services.PftpdService;
 
-public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
+public class FsFtpFile extends FsFile<FtpFile, FsFtpFileSystemView> implements FtpFile {
 	private final User user;
 
-	public FsFtpFile(File file, PftpdService pftpdService, FsFtpFileSystemView fileSystemView, User user) {
-		super(file, pftpdService, fileSystemView);
+	public FsFtpFile(FsFtpFileSystemView fileSystemView, File file, User user) {
+		super(fileSystemView, file);
 		this.user = user;
-	}
-
-	private FsFtpFileSystemView getFileSystemView() {
-		return (FsFtpFileSystemView)fileSystemView;
 	}
 
 	@Override
@@ -24,13 +20,13 @@ public class FsFtpFile extends FsFile<FtpFile> implements FtpFile {
 	}
 
 	@Override
-	protected FtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, getFileSystemView(), user);
+	protected FtpFile createFile(File file) {
+		return new FsFtpFile(getFileSystemView(), file, user);
 	}
 
 	@Override
 	public boolean move(FtpFile target) {
-		return super.move((FsFile) target);
+		return super.move((AbstractFile) target);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
@@ -13,20 +13,22 @@ import org.primftpd.services.PftpdService;
 
 public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> implements FileSystemView {
 
-	private final User user;
 	private final File homeDir;
+	private final User user;
+
 	private FsFtpFile workingDir;
 
-	public FsFtpFileSystemView(Context context, Uri safStartUrl, PftpdService pftpdService, File homeDir, User user) {
-		super(context, safStartUrl, pftpdService);
+	public FsFtpFileSystemView(PftpdService pftpdService, Uri safStartUrl, File homeDir, User user) {
+		super(pftpdService, safStartUrl);
 		this.homeDir = homeDir;
-		workingDir = getHomeDirectory();
 		this.user = user;
+
+		workingDir = getHomeDirectory();
 	}
 
 	@Override
-	protected FsFtpFile createFile(File file, PftpdService pftpdService) {
-		return new FsFtpFile(file, pftpdService, this, user);
+	protected FsFtpFile createFile(File file) {
+		return new FsFtpFile(this, file, user);
 	}
 
 	@Override
@@ -38,7 +40,7 @@ public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> im
 	public FsFtpFile getHomeDirectory() {
 		logger.trace("getHomeDirectory() -> {}", (homeDir != null ? homeDir.getAbsolutePath() : "null"));
 
-		return createFile(homeDir, pftpdService);
+		return createFile(homeDir);
 	}
 
 	public FsFtpFile getWorkingDirectory() {
@@ -100,7 +102,7 @@ public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> im
 		logger.trace("current WD '{}', new path '{}'",
 				currentAbsPath,
 				path);
-		workingDir = createFile(new File(path), pftpdService);
+		workingDir = createFile(new File(path));
 
 		return true;
 	}

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
@@ -15,15 +15,15 @@ public class FsSshFileSystemView extends FsFileSystemView<FsSshFile, SshFile> im
 	private final File homeDir;
 	private final Session session;
 
-	public FsSshFileSystemView(Context context, Uri safStartUrl, PftpdService pftpdService, File homeDir, Session session) {
-		super(context, safStartUrl, pftpdService);
+	public FsSshFileSystemView(PftpdService pftpdService, Uri safStartUrl, File homeDir, Session session) {
+		super(pftpdService, safStartUrl);
 		this.homeDir = homeDir;
 		this.session = session;
 	}
 
 	@Override
-	protected FsSshFile createFile(File file, PftpdService pftpdService) {
-		return new FsSshFile(file, pftpdService, this, session);
+	protected FsSshFile createFile(File file) {
+		return new FsSshFile(this, file, session);
 	}
 
 	@Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/MediaScannerClient.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/MediaScannerClient.java
@@ -1,0 +1,68 @@
+package org.primftpd.filesystem;
+
+import android.content.Context;
+import android.net.Uri;
+import android.media.MediaScannerConnection;
+import android.media.MediaScannerConnection.MediaScannerConnectionClient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MediaScannerClient implements MediaScannerConnectionClient {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final MediaScannerConnection connection;
+
+    public MediaScannerClient(Context context) {
+        this.connection = new MediaScannerConnection(context, this);
+
+        try {
+            // Android 11 (API level 30) and higher: this makes the connection, and isConnected() is constant true from now on
+            // Android 10 (API level 29) and lower: this initiates the connection, and we have to wait onMediaScannerConnected() before calling scanFile()
+            connection.connect();
+        } catch (Exception e) {
+            logger.warn("media scanner connection error (reconnecting later on first use) '{}'", e.toString());
+        }
+    }
+
+    private void ensureConnected() {
+        synchronized (connection) {
+            // Android 11 (API level 30) and higher: isConnected() is constant true (we called connect() in the ctor above)
+            // Android 10 (API level 29) and lower: we have to wait onMediaScannerConnected() before calling scanFile()
+            while (!connection.isConnected()) {
+                try {
+                    // calling connect() multiple times, even on an already connected connection, doesn't cause any problem
+                    connection.connect();
+                    // if we somehow miss a notifyAll(), better to use a timeout and retry
+                    connection.wait(500);
+                } catch (Exception e) {
+                    logger.warn("  media scanner connection error (reconnecting) '{}'", e.toString());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onMediaScannerConnected() {
+        synchronized (connection) {
+            connection.notifyAll();
+        }
+    }
+
+    public void scanFile(String path) {
+        logger.info("media scanning started for file '{}'", path);
+        try {
+            ensureConnected();
+            // Android 11 (API level 30) and higher: executes the scan task asynchronously
+            // Android 10 (API level 29) and lower: just requests the scan
+            connection.scanFile(path, null);
+        } catch (Exception e) {
+            logger.error("  media scanning start error '{}' for file '{}'", e.toString(), path);
+        }
+    }
+
+    @Override
+    public void onScanCompleted(String path, Uri uri) {
+        logger.info("media scanning completed for file '{}'", path);
+    }
+};

--- a/primitiveFTPd/src/org/primftpd/filesystem/QuickShareFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/QuickShareFileSystemView.java
@@ -6,33 +6,35 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
-public abstract class QuickShareFileSystemView<T extends QuickShareFile<X>, X> {
+public abstract class QuickShareFileSystemView<TFile extends QuickShareFile<TMina, ? extends QuickShareFileSystemView>, TMina> extends AbstractFileSystemView {
 
     protected final static String ROOT_PATH = "/";
     protected final static String CURRENT_PATH = ".";
     protected final static String CURRENT_ROOT_PATH = "/.";
 
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected final File tmpDir;
-    protected final PftpdService pftpdService;
 
-    QuickShareFileSystemView(File tmpDir, PftpdService pftpdService) {
+    public QuickShareFileSystemView(PftpdService pftpdService, File tmpDir) {
+		super(pftpdService);
         this.tmpDir = tmpDir;
-        this.pftpdService = pftpdService;
     }
 
-    abstract protected T createFile(File tmpDir, PftpdService pftpdService);
-    abstract protected T createFile(File tmpDir, File realFile, PftpdService pftpdService);
+    public final File getTmpDir() {
+        return tmpDir;
+    }
 
-    public T getFile(String file) {
+    abstract protected TFile createFile();
+    abstract protected TFile createFile(File realFile);
+
+    public TFile getFile(String file) {
         logger.trace("getFile({})", file);
 
-        T result;
+        TFile result;
         if (ROOT_PATH.equals(file) || CURRENT_PATH.equals(file) || CURRENT_ROOT_PATH.equals(file)) {
-            result = createFile(tmpDir, pftpdService);
+            result = createFile();
         } else {
             String filename = file.substring(file.lastIndexOf('/')+1);
-            result = createFile(tmpDir, new File(tmpDir, filename), pftpdService);
+            result = createFile(new File(tmpDir, filename));
         }
 
         return result;

--- a/primitiveFTPd/src/org/primftpd/filesystem/QuickShareFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/QuickShareFtpFile.java
@@ -6,16 +6,16 @@ import org.primftpd.services.PftpdService;
 
 import java.io.File;
 
-public class QuickShareFtpFile extends QuickShareFile<FtpFile> implements FtpFile {
+public class QuickShareFtpFile extends QuickShareFile<FtpFile, QuickShareFtpFileSystemView> implements FtpFile {
     private final User user;
 
-    QuickShareFtpFile(File tmpDir, PftpdService pftpdService, User user) {
-        super(tmpDir, pftpdService);
+    public QuickShareFtpFile(QuickShareFtpFileSystemView fileSystemView, User user) {
+        super(fileSystemView);
         this.user = user;
     }
 
-    QuickShareFtpFile(File tmpDir, File realFile, PftpdService pftpdService, User user) {
-        super(tmpDir, realFile, pftpdService);
+    public QuickShareFtpFile(QuickShareFtpFileSystemView fileSystemView, File realFile, User user) {
+        super(fileSystemView, realFile);
         this.user = user;
     }
 
@@ -25,18 +25,18 @@ public class QuickShareFtpFile extends QuickShareFile<FtpFile> implements FtpFil
     }
 
     @Override
-    protected FtpFile createFile(File tmpDir, PftpdService pftpdService) {
-        return new QuickShareFtpFile(tmpDir, pftpdService, user);
+    protected FtpFile createFile() {
+        return new QuickShareFtpFile(getFileSystemView(), user);
     }
 
     @Override
-    protected FtpFile createFile(File tmpDir, File realFile, PftpdService pftpdService) {
-        return new QuickShareFtpFile(tmpDir, realFile, pftpdService, user);
+    protected FtpFile createFile(File realFile) {
+        return new QuickShareFtpFile(getFileSystemView(), realFile, user);
     }
 
     @Override
     public boolean move(FtpFile target) {
-        return false;
+		return super.move((AbstractFile) target);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/QuickShareFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/QuickShareFtpFileSystemView.java
@@ -11,28 +11,28 @@ public class QuickShareFtpFileSystemView extends QuickShareFileSystemView<QuickS
 
     private final User user;
 
-    public QuickShareFtpFileSystemView(File quickShareFile, User user, PftpdService pftpdService) {
-        super(quickShareFile, pftpdService);
+    public QuickShareFtpFileSystemView(PftpdService pftpdService, File tmpDir, User user) {
+        super(pftpdService, tmpDir);
         this.user = user;
     }
 
-    protected QuickShareFtpFile createFile(File tmpDir, PftpdService pftpdService) {
-        return new QuickShareFtpFile(tmpDir, pftpdService, user);
+    protected QuickShareFtpFile createFile() {
+        return new QuickShareFtpFile(this, user);
     }
-    protected QuickShareFtpFile createFile(File tmpDir, File realFile, PftpdService pftpdService) {
-        return new QuickShareFtpFile(tmpDir, realFile, pftpdService, user);
+    protected QuickShareFtpFile createFile(File realFile) {
+        return new QuickShareFtpFile(this, realFile, user);
     }
 
     public QuickShareFtpFile getHomeDirectory() {
         logger.trace("getHomeDirectory()");
 
-        return createFile(tmpDir, pftpdService);
+        return createFile(tmpDir);
     }
 
     public QuickShareFtpFile getWorkingDirectory() {
         logger.trace("getWorkingDirectory()");
 
-        return createFile(tmpDir, pftpdService);
+        return createFile(tmpDir);
     }
 
     public boolean changeWorkingDirectory(String dir) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/QuickShareSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/QuickShareSshFile.java
@@ -7,27 +7,27 @@ import org.primftpd.services.PftpdService;
 import java.io.File;
 import java.util.List;
 
-public class QuickShareSshFile extends QuickShareFile<SshFile> implements SshFile {
+public class QuickShareSshFile extends QuickShareFile<SshFile, QuickShareSshFileSystemView> implements SshFile {
     private final Session session;
 
-    QuickShareSshFile(File tmpDir, PftpdService pftpdService, Session session) {
-        super(tmpDir, pftpdService);
+    public QuickShareSshFile(QuickShareSshFileSystemView fileSystemView, Session session) {
+        super(fileSystemView);
         this.session = session;
     }
 
-    QuickShareSshFile(File tmpDir, File realFile, PftpdService pftpdService, Session session) {
-        super(tmpDir, realFile, pftpdService);
+    public QuickShareSshFile(QuickShareSshFileSystemView fileSystemView, File realFile, Session session) {
+        super(fileSystemView, realFile);
         this.session = session;
     }
 
     @Override
-    protected SshFile createFile(File tmpDir, PftpdService pftpdService) {
-        return new QuickShareSshFile(tmpDir, pftpdService, session);
+    protected SshFile createFile() {
+        return new QuickShareSshFile(getFileSystemView(), session);
     }
 
     @Override
-    protected SshFile createFile(File tmpDir, File realFile, PftpdService pftpdService) {
-        return new QuickShareSshFile(tmpDir, realFile, pftpdService, session);
+    protected SshFile createFile(File realFile) {
+        return new QuickShareSshFile(getFileSystemView(), realFile, session);
     }
 
     @Override
@@ -36,8 +36,8 @@ public class QuickShareSshFile extends QuickShareFile<SshFile> implements SshFil
     }
 
     @Override
-    public boolean move(org.apache.sshd.common.file.SshFile target) {
-        return false;
+    public boolean move(SshFile target) {
+		return super.move((AbstractFile) target);
     }
 
     @Override
@@ -48,20 +48,15 @@ public class QuickShareSshFile extends QuickShareFile<SshFile> implements SshFil
 
     @Override
     public boolean create() {
-        logger.trace("[{}] create()", name);
-        return false;
+        boolean result = false;
+        logger.trace("[{}] create() -> {}", name, result);
+        return result;
     }
 
     @Override
     public SshFile getParentFile() {
         logger.trace("[{}] getParentFile()", name);
-        return new QuickShareSshFile(tmpDir, pftpdService, session);
-    }
-
-    @Override
-    public boolean isExecutable() {
-        logger.trace("[{}] isExecutable()", name);
-        return false;
+        return new QuickShareSshFile(getFileSystemView(), session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/QuickShareSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/QuickShareSshFileSystemView.java
@@ -11,16 +11,16 @@ public class QuickShareSshFileSystemView extends QuickShareFileSystemView<QuickS
 
     private final Session session;
 
-    public QuickShareSshFileSystemView(File quickShareFile, PftpdService pftpdService, Session session) {
-        super(quickShareFile, pftpdService);
+    public QuickShareSshFileSystemView(PftpdService pftpdService, File tmpDir, Session session) {
+        super(pftpdService, tmpDir);
         this.session = session;
     }
 
-    protected QuickShareSshFile createFile(File tmpDir, PftpdService pftpdService) {
-        return new QuickShareSshFile(tmpDir, pftpdService, session);
+    protected QuickShareSshFile createFile() {
+        return new QuickShareSshFile(this, session);
     }
-    protected QuickShareSshFile createFile(File tmpDir, File realFile, PftpdService pftpdService) {
-        return new QuickShareSshFile(tmpDir, realFile, pftpdService, session);
+    protected QuickShareSshFile createFile(File realFile) {
+        return new QuickShareSshFile(this, realFile, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFile.java
@@ -8,58 +8,40 @@ import org.apache.ftpserver.ftplet.FtpFile;
 import org.apache.ftpserver.ftplet.User;
 import org.primftpd.services.PftpdService;
 
-public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
+public class RoSafFtpFile extends RoSafFile<FtpFile, RoSafFtpFileSystemView> implements FtpFile {
 
     private final User user;
 
     public RoSafFtpFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
-            String absPath,
-            PftpdService pftpdService,
             RoSafFtpFileSystemView fileSystemView,
+            String absPath,
             User user) {
-        super(contentResolver, startUrl, absPath, pftpdService, fileSystemView);
+        super(fileSystemView, absPath);
         this.user = user;
     }
 
     public RoSafFtpFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
+            RoSafFtpFileSystemView fileSystemView,
+            String absPath,
             String docId,
-            String absPath,
             boolean exists,
-            PftpdService pftpdService,
-            RoSafFtpFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, fileSystemView);
+        super(fileSystemView, absPath, docId, exists);
         this.user = user;
     }
 
-    public RoSafFtpFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
-            Cursor cursor,
+    protected RoSafFtpFile(
+            RoSafFtpFileSystemView fileSystemView,
             String absPath,
-            PftpdService pftpdService,
-            RoSafFtpFileSystemView fileSystemView,
+            Cursor cursor,
             User user) {
-        super(contentResolver, startUrl, cursor, absPath, pftpdService, fileSystemView);
+        super(fileSystemView, absPath, cursor);
         this.user = user;
-    }
-
-    private RoSafFtpFileSystemView getFileSystemView() {
-        return (RoSafFtpFileSystemView)fileSystemView;
     }
 
     @Override
-    protected FtpFile createFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
-            Cursor cursor,
-            String absPath,
-            PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, cursor, absPath, pftpdService, getFileSystemView(), user);
+    protected FtpFile createFile(String absPath, Cursor cursor) {
+        return new RoSafFtpFile(getFileSystemView(), absPath, cursor, user);
     }
 
     @Override
@@ -69,8 +51,7 @@ public class RoSafFtpFile extends RoSafFile<FtpFile> implements FtpFile {
 
     @Override
     public boolean move(FtpFile target) {
-        logger.trace("move()");
-        return super.move((RoSafFile)target);
+        return super.move((AbstractFile)target);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafFtpFileSystemView.java
@@ -12,26 +12,24 @@ import org.primftpd.services.PftpdService;
 public class RoSafFtpFileSystemView extends RoSafFileSystemView<RoSafFtpFile, FtpFile> implements FileSystemView {
 
     private final User user;
+
     private RoSafFtpFile workingDir;
 
-    public RoSafFtpFileSystemView(Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService, User user) {
-        super(startUrl, contentResolver, pftpdService);
+    public RoSafFtpFileSystemView(PftpdService pftpdService, Uri startUrl, User user) {
+        super(pftpdService, startUrl);
         this.user = user;
+
         this.workingDir = getHomeDirectory();
     }
 
     @Override
-    protected RoSafFtpFile createFile(ContentResolver contentResolver, Uri startUrl, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, absPath, pftpdService, this, user);
+    protected RoSafFtpFile createFile(String absPath) {
+        return new RoSafFtpFile(this, absPath, user);
     }
 
     @Override
-    protected RoSafFtpFile createFile(ContentResolver contentResolver, Uri startUrl, String docId, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, docId, absPath, true, pftpdService, this, user);
-    }
-
-    protected RoSafFtpFile createFileNonExistent(ContentResolver contentResolver, Uri startUrl, String name, String absPath, PftpdService pftpdService) {
-        return new RoSafFtpFile(contentResolver, startUrl, name, absPath, false, pftpdService, this, user);
+    protected RoSafFtpFile createFile(String absPath, String docId, boolean exists) {
+        return new RoSafFtpFile(this, absPath, docId, exists, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFile.java
@@ -10,58 +10,40 @@ import org.primftpd.services.PftpdService;
 
 import java.util.List;
 
-public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
+public class RoSafSshFile extends RoSafFile<SshFile, RoSafSshFileSystemView> implements SshFile {
 
     private final Session session;
 
     public RoSafSshFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
-            String absPath,
-            PftpdService pftpdService,
             RoSafSshFileSystemView fileSystemView,
+            String absPath,
             Session session) {
-        super(contentResolver, startUrl, absPath, pftpdService, fileSystemView);
+        super(fileSystemView, absPath);
         this.session = session;
     }
 
     public RoSafSshFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
+            RoSafSshFileSystemView fileSystemView,
+            String absPath,
             String docId,
-            String absPath,
             boolean exists,
-            PftpdService pftpdService,
-            RoSafSshFileSystemView fileSystemView,
             Session session) {
-        super(contentResolver, startUrl, docId, absPath, exists, pftpdService, fileSystemView);
+        super(fileSystemView, absPath, docId, exists);
         this.session = session;
     }
 
-    public RoSafSshFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
-            Cursor cursor,
+    protected RoSafSshFile(
+            RoSafSshFileSystemView fileSystemView,
             String absPath,
-            PftpdService pftpdService,
-            RoSafSshFileSystemView fileSystemView,
+            Cursor cursor,
             Session session) {
-        super(contentResolver, startUrl, cursor, absPath, pftpdService, fileSystemView);
+        super(fileSystemView, absPath, cursor);
         this.session = session;
-    }
-
-    private RoSafSshFileSystemView getFileSystemView() {
-        return (RoSafSshFileSystemView)fileSystemView;
     }
 
     @Override
-    protected SshFile createFile(
-            ContentResolver contentResolver,
-            Uri startUrl,
-            Cursor cursor,
-            String absPath,
-            PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, cursor, absPath, pftpdService, getFileSystemView(), session);
+    protected SshFile createFile(String absPath, Cursor cursor) {
+        return new RoSafSshFile(getFileSystemView(), absPath, cursor, session);
     }
 
     @Override
@@ -71,8 +53,7 @@ public class RoSafSshFile extends RoSafFile<SshFile> implements SshFile {
 
     @Override
     public boolean move(SshFile target) {
-        logger.trace("move()");
-        return super.move((RoSafFile)target);
+        return super.move((AbstractFile)target);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RoSafSshFileSystemView.java
@@ -12,24 +12,19 @@ public class RoSafSshFileSystemView extends RoSafFileSystemView<RoSafSshFile, Ss
 
     private final Session session;
 
-    public RoSafSshFileSystemView(Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService, Session session) {
-        super(startUrl, contentResolver, pftpdService);
+    public RoSafSshFileSystemView(PftpdService pftpdService, Uri startUrl, Session session) {
+        super(pftpdService, startUrl);
         this.session = session;
     }
 
     @Override
-    protected RoSafSshFile createFile(ContentResolver contentResolver, Uri startUrl, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, absPath, pftpdService, this, session);
+    protected RoSafSshFile createFile(String absPath) {
+        return new RoSafSshFile(this, absPath, session);
     }
 
     @Override
-    protected RoSafSshFile createFile(ContentResolver contentResolver, Uri startUrl, String docId, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, docId, absPath, true, pftpdService, this, session);
-    }
-
-    @Override
-    protected RoSafSshFile createFileNonExistent(ContentResolver contentResolver, Uri startUrl, String name, String absPath, PftpdService pftpdService) {
-        return new RoSafSshFile(contentResolver, startUrl, name, absPath, false, pftpdService, this, session);
+    protected RoSafSshFile createFile(String absPath, String docId, boolean exists) {
+        return new RoSafSshFile(this, absPath, docId, exists, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RootFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RootFileSystemView.java
@@ -10,23 +10,30 @@ import java.util.List;
 
 import eu.chainfire.libsuperuser.Shell;
 
-public abstract class RootFileSystemView<T extends RootFile<X>, X> {
+public abstract class RootFileSystemView<TFile extends RootFile<TMina, ? extends RootFileSystemView>, TMina> extends AbstractFileSystemView {
 
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
-
+    private final MediaScannerClient mediaScannerClient;
     protected final Shell.Interactive shell;
-    protected final PftpdService pftpdService;
 
-    public RootFileSystemView(Shell.Interactive shell, PftpdService pftpdService) {
+    public RootFileSystemView(PftpdService pftpdService, Shell.Interactive shell) {
+        super(pftpdService);
+        this.mediaScannerClient = new MediaScannerClient(pftpdService.getContext());
         this.shell = shell;
-        this.pftpdService = pftpdService;
     }
 
-    protected abstract T createFile(LsOutputBean bean, String absPath, PftpdService pftpdService);
+    public final MediaScannerClient getMediaScannerClient() {
+        return mediaScannerClient;
+    }
+
+    public final Shell.Interactive getShell() {
+        return shell;
+    }
+
+    protected abstract TFile createFile(String absPath, LsOutputBean bean);
 
     protected abstract String absolute(String file);
 
-    public T getFile(String file) {
+    public TFile getFile(String file) {
         logger.trace("getFile({})", file);
 
         String abs = absolute(file);
@@ -60,7 +67,7 @@ public abstract class RootFileSystemView<T extends RootFile<X>, X> {
             //    // TODO make sym link target absolute
             //    abs = bean.getName();
             //}
-            return createFile(bean, abs, pftpdService);
+            return createFile(abs, bean);
         } else {
             // probably new
             String name;
@@ -70,7 +77,7 @@ public abstract class RootFileSystemView<T extends RootFile<X>, X> {
                 name = abs;
             }
             bean = new LsOutputBean(name);
-            return createFile(bean, abs, pftpdService);
+            return createFile(abs, bean);
         }
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/RootFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RootFtpFile.java
@@ -13,17 +13,17 @@ import java.io.OutputStream;
 
 import eu.chainfire.libsuperuser.Shell;
 
-public class RootFtpFile extends RootFile<FtpFile> implements FtpFile {
+public class RootFtpFile extends RootFile<FtpFile, RootFtpFileSystemView> implements FtpFile {
 
     private final User user;
 
-    public RootFtpFile(Shell.Interactive shell, LsOutputBean bean, String absPath, PftpdService pftpdService, User user) {
-        super(shell, bean, absPath, pftpdService);
+    public RootFtpFile(RootFtpFileSystemView fileSystemView, String absPath, LsOutputBean bean, User user) {
+        super(fileSystemView, absPath, bean);
         this.user = user;
     }
 
-    protected RootFtpFile createFile(Shell.Interactive shell, LsOutputBean bean, String absPath, PftpdService pftpdService) {
-        return new RootFtpFile(shell, bean, absPath, pftpdService, user);
+    protected RootFtpFile createFile(String absPath, LsOutputBean bean) {
+        return new RootFtpFile(getFileSystemView(), absPath, bean, user);
     }
 
     @Override
@@ -59,8 +59,7 @@ public class RootFtpFile extends RootFile<FtpFile> implements FtpFile {
 
     @Override
     public boolean move(FtpFile target) {
-        logger.trace("move()");
-        return super.move((RootFile)target);
+        return super.move((AbstractFile)target);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RootFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RootFtpFileSystemView.java
@@ -13,19 +13,22 @@ import eu.chainfire.libsuperuser.Shell;
 
 public class RootFtpFileSystemView extends RootFileSystemView<RootFtpFile, FtpFile> implements FileSystemView {
 
-    private final User user;
     private final RootFtpFile homeDir;
+    private final User user;
+
     private RootFtpFile workingDir;
 
-    public RootFtpFileSystemView(Shell.Interactive shell, PftpdService pftpdService, File homeDir, User user) {
-        super(shell, pftpdService);
+    public RootFtpFileSystemView(PftpdService pftpdService, Shell.Interactive shell, File homeDir, User user) {
+        super(pftpdService, shell);
+        this.homeDir = getFile(homeDir.getAbsolutePath());
         this.user = user;
-        this.workingDir = this.homeDir = getFile(homeDir.getAbsolutePath());
+
+        workingDir = this.homeDir;
     }
 
     @Override
-    protected RootFtpFile createFile(LsOutputBean bean, String absPath, PftpdService pftpdService) {
-        return new RootFtpFile(shell, bean, absPath, pftpdService, user);
+    protected RootFtpFile createFile(String absPath, LsOutputBean bean) {
+        return new RootFtpFile(this, absPath, bean, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RootSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RootSshFileSystemView.java
@@ -15,15 +15,15 @@ public class RootSshFileSystemView extends RootFileSystemView<RootSshFile, SshFi
     private final File homeDir;
     private final Session session;
 
-    public RootSshFileSystemView(Shell.Interactive shell, PftpdService pftpdService, File homeDir, Session session) {
-        super(shell, pftpdService);
+    public RootSshFileSystemView(PftpdService pftpdService, Shell.Interactive shell, File homeDir, Session session) {
+        super(pftpdService, shell);
         this.homeDir = homeDir;
         this.session = session;
     }
 
     @Override
-    protected RootSshFile createFile(LsOutputBean bean, String absPath, PftpdService pftpdService) {
-        return new RootSshFile(shell, bean, absPath, pftpdService, session, this);
+    protected RootSshFile createFile(String absPath, LsOutputBean bean) {
+        return new RootSshFile(this, absPath, bean, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFile.java
@@ -7,46 +7,39 @@ import org.apache.ftpserver.ftplet.FtpFile;
 import org.apache.ftpserver.ftplet.User;
 import org.primftpd.services.PftpdService;
 
-public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
+import java.util.List;
+
+public class SafFtpFile extends SafFile<FtpFile, SafFtpFileSystemView> implements FtpFile {
 
     private final User user;
 
     public SafFtpFile(
-            ContentResolver contentResolver,
+            SafFtpFileSystemView fileSystemView,
+            String absPath,
             DocumentFile parentDocumentFile,
             DocumentFile documentFile,
-            String absPath,
-            PftpdService pftpdService,
-            SafFtpFileSystemView fileSystemView,
             User user) {
-        super(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, fileSystemView);
+        super(fileSystemView, absPath, parentDocumentFile, documentFile);
         this.user = user;
     }
 
     public SafFtpFile(
-            ContentResolver contentResolver,
-            DocumentFile parentDocumentFile,
-            String name,
-            String absPath,
-            PftpdService pftpdService,
             SafFtpFileSystemView fileSystemView,
+            String absPath,
+            DocumentFile parentDocumentFile,
+            List<String> parentNonexistentDirs,
+            String name,
             User user) {
-        super(contentResolver, parentDocumentFile, name, absPath, pftpdService, fileSystemView);
+        super(fileSystemView, absPath, parentDocumentFile, parentNonexistentDirs, name);
         this.user = user;
-    }
-
-    private SafFtpFileSystemView getFileSystemView() {
-        return (SafFtpFileSystemView)fileSystemView;
     }
 
     @Override
     protected FtpFile createFile(
-            ContentResolver contentResolver,
-            DocumentFile parentDocumentFile,
-            DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, getFileSystemView(), user);
+            DocumentFile parentDocumentFile,
+            DocumentFile documentFile) {
+        return new SafFtpFile(getFileSystemView(), absPath, parentDocumentFile, documentFile, user);
     }
 
     @Override
@@ -56,8 +49,7 @@ public class SafFtpFile extends SafFile<FtpFile> implements FtpFile {
 
     @Override
     public boolean move(FtpFile target) {
-        logger.trace("move()");
-        return super.move((SafFile)target);
+        return super.move((AbstractFile)target);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFtpFileSystemView.java
@@ -11,37 +11,38 @@ import org.apache.ftpserver.ftplet.FtpFile;
 import org.apache.ftpserver.ftplet.User;
 import org.primftpd.services.PftpdService;
 
+import java.util.List;
+
 public class SafFtpFileSystemView extends SafFileSystemView<SafFtpFile, FtpFile> implements FileSystemView {
 
     private final User user;
+
     private SafFtpFile workingDir;
 
-    public SafFtpFileSystemView(Context context, Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService, User user) {
-        super(context, startUrl, contentResolver, pftpdService);
+    public SafFtpFileSystemView(PftpdService pftpdService, Uri startUrl, User user) {
+        super(pftpdService, startUrl);
         this.user = user;
+
         this.workingDir = getHomeDirectory();
     }
 
     @Override
     protected SafFtpFile createFile(
-            ContentResolver contentResolver,
-            DocumentFile parentDocumentFile,
-            DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
+            DocumentFile parentDocumentFile,
+            DocumentFile documentFile) {
         logger.trace("createFile(DocumentFile)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, this, user);
+        return new SafFtpFile(this, absPath, parentDocumentFile, documentFile, user);
     }
 
     @Override
     protected SafFtpFile createFile(
-            ContentResolver contentResolver,
-            DocumentFile parentDocumentFile,
-            String name,
             String absPath,
-            PftpdService pftpdService) {
+            DocumentFile parentDocumentFile,
+            List<String> parentNonexistentDirs,
+            String name) {
         logger.trace("createFile(String)");
-        return new SafFtpFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, this, user);
+        return new SafFtpFile(this, absPath, parentDocumentFile, parentNonexistentDirs, name, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFileSystemView.java
@@ -10,33 +10,32 @@ import org.apache.sshd.common.file.FileSystemView;
 import org.apache.sshd.common.file.SshFile;
 import org.primftpd.services.PftpdService;
 
+import java.util.List;
+
 public class SafSshFileSystemView extends SafFileSystemView<SafSshFile, SshFile> implements FileSystemView {
 
     private final Session session;
 
-    public SafSshFileSystemView(Context context, Uri startUrl, ContentResolver contentResolver, PftpdService pftpdService, Session session) {
-        super(context, startUrl, contentResolver, pftpdService);
+    public SafSshFileSystemView(PftpdService pftpdService, Uri startUrl, Session session) {
+        super(pftpdService, startUrl);
         this.session = session;
     }
 
     @Override
     protected SafSshFile createFile(
-            ContentResolver contentResolver,
-            DocumentFile parentDocumentFile,
-            DocumentFile documentFile,
             String absPath,
-            PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, documentFile, absPath, pftpdService, this, session);
+            DocumentFile parentDocumentFile,
+            DocumentFile documentFile) {
+        return new SafSshFile(this, absPath, parentDocumentFile, documentFile, session);
     }
 
     @Override
     protected SafSshFile createFile(
-            ContentResolver contentResolver,
-            DocumentFile parentDocumentFile,
-            String name,
             String absPath,
-            PftpdService pftpdService) {
-        return new SafSshFile(contentResolver, parentDocumentFile, name, absPath, pftpdService, this, session);
+            DocumentFile parentDocumentFile,
+            List<String> parentNonexistentDirs,
+            String name) {
+        return new SafSshFile(this, absPath, parentDocumentFile, parentNonexistentDirs, name, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/Utils.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/Utils.java
@@ -1,10 +1,5 @@
 package org.primftpd.filesystem;
 
-import android.content.Context;
-import android.media.MediaScannerConnection;
-import android.net.Uri;
-import android.os.AsyncTask;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,25 +77,6 @@ public class Utils {
     }
     static String touchDate(long time) {
         return TOUCH_DATE_FORMAT.format(time);
-    }
-
-    static void mediaScanFile(Context context, String absPath) {
-        MediaScannerConnection con = new MediaScannerConnection(context, new MediaScannerConnection.MediaScannerConnectionClient() {
-            @Override
-            public void onMediaScannerConnected() {
-            }
-            @Override
-            public void onScanCompleted(String path, Uri uri) {
-            }
-        });
-        new AsyncTask<Void, Void, Void>() {
-            @Override
-            protected Void doInBackground(Void... voids) {
-                logger.info("media scanning file: {}", absPath);
-                con.scanFile(absPath, null);
-                return null;
-            }
-        };
     }
 
     public static final boolean RUN_TESTS = false;

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFileSystemView.java
@@ -5,78 +5,74 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class VirtualFileSystemView<
-        MinaType,
-        FsType extends FsFile<MinaType>,
-        RootType extends RootFile<MinaType>,
-        SafType extends SafFile<MinaType>,
-        RoSafType extends RoSafFile<MinaType>
-        > {
+        TFsFile extends FsFile<TMina, ? extends FsFileSystemView>,
+        TRootFile extends RootFile<TMina, ? extends RootFileSystemView>,
+        TSafFile extends SafFile<TMina, ? extends SafFileSystemView>,
+        TRoSafFile extends RoSafFile<TMina, ? extends RoSafFileSystemView>,
+        TMina> extends AbstractFileSystemView {
 
     public static final String PREFIX_FS = "fs";
     public static final String PREFIX_ROOT = "superuser";
     public static final String PREFIX_SAF = "saf";
     public static final String PREFIX_ROSAF = "rosaf";
 
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
-
-    protected final FsFileSystemView<FsType, MinaType> fsFileSystemView;
-    protected final RootFileSystemView<RootType, MinaType> rootFileSystemView;
-    protected final SafFileSystemView<SafType, MinaType> safFileSystemView;
-    protected final RoSafFileSystemView<RoSafType, MinaType> roSafFileSystemView;
-    protected final PftpdService pftpdService;
+    protected final FsFileSystemView<TFsFile, TMina> fsFileSystemView;
+    protected final RootFileSystemView<TRootFile, TMina> rootFileSystemView;
+    protected final SafFileSystemView<TSafFile, TMina> safFileSystemView;
+    protected final RoSafFileSystemView<TRoSafFile, TMina> roSafFileSystemView;
 
     public VirtualFileSystemView(
-            FsFileSystemView<FsType, MinaType> fsFileSystemView,
-            RootFileSystemView<RootType, MinaType> rootFileSystemView,
-            SafFileSystemView<SafType, MinaType> safFileSystemView,
-            RoSafFileSystemView<RoSafType, MinaType> roSafFileSystemView,
-            PftpdService pftpdService) {
+            PftpdService pftpdService,
+            FsFileSystemView<TFsFile, TMina> fsFileSystemView,
+            RootFileSystemView<TRootFile, TMina> rootFileSystemView,
+            SafFileSystemView<TSafFile, TMina> safFileSystemView,
+            RoSafFileSystemView<TRoSafFile, TMina> roSafFileSystemView) {
+        super(pftpdService);
         this.fsFileSystemView = fsFileSystemView;
         this.rootFileSystemView = rootFileSystemView;
         this.safFileSystemView = safFileSystemView;
         this.roSafFileSystemView = roSafFileSystemView;
-        this.pftpdService = pftpdService;
     }
 
-    public abstract MinaType createFile(String absPath, AbstractFile delegate, PftpdService pftpdService);
-    public abstract MinaType createFile(String absPath, AbstractFile delegate, boolean exists, PftpdService pftpdService);
+    public abstract TMina createFile(String absPath, AbstractFile delegate);
+    public abstract TMina createFile(String absPath, boolean exists);
 
     public abstract AbstractFile getConfigFile();
 
     protected abstract String absolute(String file);
 
-    public MinaType getFile(String file) {
+    public TMina getFile(String file) {
         String absoluteVirtualPath = absolute(file);
         logger.debug("getFile '{}', absolute: '{}'", file, absoluteVirtualPath);
         if ("/".equals(absoluteVirtualPath)) {
-            return createFile(absoluteVirtualPath, null, true, pftpdService);
+            return createFile(absoluteVirtualPath, true);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_FS)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_FS);
             logger.debug("Using FS '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = fsFileSystemView.getFile(realPath);
-            return createFile(absoluteVirtualPath, delegate, pftpdService);
+            return createFile(absoluteVirtualPath, delegate);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_ROOT)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_ROOT);
             logger.debug("Using ROOT '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = rootFileSystemView.getFile(realPath);
-            return createFile(absoluteVirtualPath, delegate, pftpdService);
+            return createFile(absoluteVirtualPath, delegate);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_SAF)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_SAF);
             logger.debug("Using SAF '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = safFileSystemView.getFile(realPath);
-            return createFile(absoluteVirtualPath, delegate, pftpdService);
+            return createFile(absoluteVirtualPath, delegate);
         } else if (absoluteVirtualPath.startsWith("/" + PREFIX_ROSAF)) {
             String realPath = toRealPath(absoluteVirtualPath, "/" + PREFIX_ROSAF);
             logger.debug("Using ROSAF '{}' for '{}'", realPath, absoluteVirtualPath);
             AbstractFile delegate = roSafFileSystemView.getFile(realPath);
-            return createFile(absoluteVirtualPath, delegate, pftpdService);
+            return createFile(absoluteVirtualPath, delegate);
         } else if (VirtualConfigFile.ABS_PATH.equals(absoluteVirtualPath)) {
             logger.debug("Using VirtualFile for CONFIG path '{}'", absoluteVirtualPath);
             AbstractFile delegate = getConfigFile();
-            return createFile(absoluteVirtualPath, delegate, pftpdService);
+            return createFile(absoluteVirtualPath, delegate);
         } else{
             logger.debug("Using VirtualFile for unknown path '{}'", absoluteVirtualPath);
-            return createFile(absoluteVirtualPath, null, false, pftpdService);
+            return createFile(absoluteVirtualPath, false);
         }
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpConfigFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpConfigFile.java
@@ -3,12 +3,12 @@ package org.primftpd.filesystem;
 import org.apache.ftpserver.ftplet.User;
 import org.primftpd.services.PftpdService;
 
-public class VirtualFtpConfigFile extends VirtualConfigFile {
+public class VirtualFtpConfigFile extends VirtualConfigFile<VirtualFtpFileSystemView> {
 
     private final User user;
 
-    public VirtualFtpConfigFile(PftpdService pftpdService, User user) {
-        super(pftpdService);
+    public VirtualFtpConfigFile(VirtualFtpFileSystemView fileSystemView, User user) {
+        super(fileSystemView);
         this.user = user;
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFile.java
@@ -6,28 +6,28 @@ import org.primftpd.services.PftpdService;
 
 import java.util.List;
 
-public class VirtualFtpFile extends VirtualFile<FtpFile> implements FtpFile {
+public class VirtualFtpFile extends VirtualFile<FtpFile, VirtualFtpFileSystemView> implements FtpFile {
 
     private final User user;
 
-    public VirtualFtpFile(String absPath, AbstractFile delegate, PftpdService pftpdService, User user) {
-        super(absPath, delegate, pftpdService);
+    public VirtualFtpFile(VirtualFtpFileSystemView fileSystemView, String absPath, AbstractFile delegate, User user) {
+        super(fileSystemView, absPath, delegate);
         this.user = user;
     }
 
-    public VirtualFtpFile(String absPath, AbstractFile delegate, boolean exists, PftpdService pftpdService, User user) {
-        super(absPath, delegate, exists, pftpdService);
+    public VirtualFtpFile(VirtualFtpFileSystemView fileSystemView, String absPath, boolean exists, User user) {
+        super(fileSystemView, absPath, exists);
         this.user = user;
     }
 
     @Override
-    protected FtpFile createFile(String absPath, AbstractFile delegate, PftpdService pftpdService) {
-        return new VirtualFtpFile(absPath, delegate, pftpdService, user);
+    protected FtpFile createFile(String absPath, AbstractFile delegate) {
+        return new VirtualFtpFile(getFileSystemView(), absPath, delegate, user);
     }
 
     @Override
-    protected FtpFile createFile(String absPath, AbstractFile delegate, boolean exists, PftpdService pftpdService) {
-        return new VirtualFtpFile(absPath, delegate, exists, pftpdService, user);
+    protected FtpFile createFile(String absPath, boolean exists) {
+        return new VirtualFtpFile(getFileSystemView(), absPath, exists, user);
     }
 
     @Override
@@ -43,9 +43,7 @@ public class VirtualFtpFile extends VirtualFile<FtpFile> implements FtpFile {
 
     @Override
     public boolean move(FtpFile target) {
-        logger.trace("move()");
-        FtpFile realTarget = (FtpFile) ((VirtualFtpFile) target).delegate;
-        return delegate != null && ((FtpFile) delegate).move(realTarget);
+        return super.move(((VirtualFile)target).delegate);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualFtpFileSystemView.java
@@ -8,43 +8,45 @@ import org.primftpd.services.PftpdService;
 import java.io.File;
 
 public class VirtualFtpFileSystemView extends VirtualFileSystemView<
-        FtpFile,
         FsFtpFile,
         RootFtpFile,
         SafFtpFile,
-        RoSafFtpFile> implements FileSystemView {
+        RoSafFtpFile,
+        FtpFile> implements FileSystemView {
 
-    private final User user;
     private final File homeDir;
+    private final User user;
+
     private FtpFile workingDir;
 
     public VirtualFtpFileSystemView(
+            PftpdService pftpdService,
             FsFtpFileSystemView fsFileSystemView,
             RootFtpFileSystemView rootFileSystemView,
             SafFtpFileSystemView safFileSystemView,
             RoSafFtpFileSystemView roSafFileSystemView,
-            PftpdService pftpdService,
             File homeDir,
             User user) {
-        super(fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView, pftpdService);
-        this.user = user;
+        super(pftpdService, fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView);
         this.homeDir = homeDir;
+        this.user = user;
+
         workingDir = getHomeDirectory();
     }
 
     @Override
-    public FtpFile createFile(String absPath, AbstractFile delegate, PftpdService pftpdService) {
-        return new VirtualFtpFile(absPath, delegate, pftpdService, user);
+    public FtpFile createFile(String absPath, AbstractFile delegate) {
+        return new VirtualFtpFile(this, absPath, delegate, user);
     }
 
     @Override
-    public FtpFile createFile(String absPath, AbstractFile delegate, boolean exists, PftpdService pftpdService) {
-        return new VirtualFtpFile(absPath, delegate, exists, pftpdService, user);
+    public FtpFile createFile(String absPath, boolean exists) {
+        return new VirtualFtpFile(this, absPath, exists, user);
     }
 
     @Override
     public AbstractFile getConfigFile() {
-        return new VirtualFtpConfigFile(pftpdService, user);
+        return new VirtualFtpConfigFile(this, user);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshConfigFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshConfigFile.java
@@ -3,12 +3,12 @@ package org.primftpd.filesystem;
 import org.apache.sshd.common.Session;
 import org.primftpd.services.PftpdService;
 
-public class VirtualSshConfigFile extends VirtualConfigFile {
+public class VirtualSshConfigFile extends VirtualConfigFile<VirtualSshFileSystemView> {
 
     private final Session session;
 
-    public VirtualSshConfigFile(PftpdService pftpdService, Session session) {
-        super(pftpdService);
+    public VirtualSshConfigFile(VirtualSshFileSystemView fileSystemView, Session session) {
+        super(fileSystemView);
         this.session = session;
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFileSystemView.java
@@ -8,41 +8,41 @@ import org.primftpd.services.PftpdService;
 import java.io.File;
 
 public class VirtualSshFileSystemView extends VirtualFileSystemView<
-        SshFile,
         FsSshFile,
         RootSshFile,
         SafSshFile,
-        RoSafSshFile> implements FileSystemView {
+        RoSafSshFile,
+        SshFile> implements FileSystemView {
 
     private final File homeDir;
     private final Session session;
 
     public VirtualSshFileSystemView(
+            PftpdService pftpdService,
             FsSshFileSystemView fsFileSystemView,
             RootSshFileSystemView rootFileSystemView,
             SafSshFileSystemView safFileSystemView,
             RoSafSshFileSystemView roSafFileSystemView,
-            PftpdService pftpdService,
             File homeDir,
             Session session) {
-        super(fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView, pftpdService);
+        super(pftpdService, fsFileSystemView, rootFileSystemView, safFileSystemView, roSafFileSystemView);
         this.homeDir = homeDir;
         this.session = session;
     }
 
     @Override
-    public SshFile createFile(String absPath, AbstractFile delegate, PftpdService pftpdService) {
-        return new VirtualSshFile(absPath, delegate, pftpdService, session);
+    public SshFile createFile(String absPath, AbstractFile delegate) {
+        return new VirtualSshFile(this, absPath, delegate, session);
     }
 
     @Override
-    public SshFile createFile(String absPath, AbstractFile delegate, boolean exists, PftpdService pftpdService) {
-        return new VirtualSshFile(absPath, delegate, exists, pftpdService, session);
+    public SshFile createFile(String absPath, boolean exists) {
+        return new VirtualSshFile(this, absPath, exists, session);
     }
 
     @Override
     public AbstractFile getConfigFile() {
-        return new VirtualSshConfigFile(pftpdService, session);
+        return new VirtualSshConfigFile(this, session);
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
@@ -115,54 +115,54 @@ public class FtpServerService extends AbstractServerService
 				if (quickShareBean != null) {
 					logger.debug("launching server in quick share mode");
 					return new QuickShareFtpFileSystemView(
+							FtpServerService.this,
 							quickShareBean.getTmpDir(),
-							user,
-							FtpServerService.this);
+							user);
 				} else {
 					switch (prefsBean.getStorageType()) {
 						case PLAIN:
 							return new FsFtpFileSystemView(
-									getApplicationContext(),
-									Uri.parse(prefsBean.getSafUrl()),
 									FtpServerService.this,
+									Uri.parse(prefsBean.getSafUrl()),
 									prefsBean.getStartDir(),
 									user);
 						case ROOT:
-							return new RootFtpFileSystemView(shell, FtpServerService.this, prefsBean.getStartDir(), user);
+							return new RootFtpFileSystemView(
+									FtpServerService.this,
+									shell,
+									prefsBean.getStartDir(),
+									user);
 						case SAF:
 							return new SafFtpFileSystemView(
-									getApplicationContext(),
-									Uri.parse(prefsBean.getSafUrl()),
-									getContentResolver(),
 									FtpServerService.this,
+									Uri.parse(prefsBean.getSafUrl()),
 									user);
 						case RO_SAF:
 							return new RoSafFtpFileSystemView(
-									Uri.parse(prefsBean.getSafUrl()),
-									getContentResolver(),
 									FtpServerService.this,
+									Uri.parse(prefsBean.getSafUrl()),
 									user);
 						case VIRTUAL:
 							return new VirtualFtpFileSystemView(
+									FtpServerService.this,
 									new FsFtpFileSystemView(
-											getApplicationContext(),
-											Uri.parse(prefsBean.getSafUrl()),
 											FtpServerService.this,
+											Uri.parse(prefsBean.getSafUrl()),
 											prefsBean.getStartDir(),
 											user),
-									new RootFtpFileSystemView(shell, FtpServerService.this, prefsBean.getStartDir(), user),
-									new SafFtpFileSystemView(
-											getApplicationContext(),
-											Uri.parse(prefsBean.getSafUrl()),
-											getContentResolver(),
+									new RootFtpFileSystemView(
 											FtpServerService.this,
+											shell,
+											prefsBean.getStartDir(),
+											user),
+									new SafFtpFileSystemView(
+											FtpServerService.this,
+											Uri.parse(prefsBean.getSafUrl()),
 											user),
 									new RoSafFtpFileSystemView(
-											Uri.parse(prefsBean.getSafUrl()),
-											getContentResolver(),
 											FtpServerService.this,
+											Uri.parse(prefsBean.getSafUrl()),
 											user),
-									FtpServerService.this,
 									prefsBean.getStartDir(),
 									user
 							);

--- a/primitiveFTPd/src/org/primftpd/services/SshServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/SshServerService.java
@@ -200,54 +200,54 @@ public class SshServerService extends AbstractServerService
 				if (quickShareBean != null) {
 					logger.debug("launching server in quick share mode");
 					return new QuickShareSshFileSystemView(
-							quickShareBean.getTmpDir(),
 							SshServerService.this,
+							quickShareBean.getTmpDir(),
 							session);
 				} else {
 					switch (prefsBean.getStorageType()) {
 						case PLAIN:
 							return new FsSshFileSystemView(
-									getApplicationContext(),
-									Uri.parse(prefsBean.getSafUrl()),
 									SshServerService.this,
+									Uri.parse(prefsBean.getSafUrl()),
 									prefsBean.getStartDir(),
 									session);
 						case ROOT:
-							return new RootSshFileSystemView(shell, SshServerService.this, prefsBean.getStartDir(), session);
+							return new RootSshFileSystemView(
+									SshServerService.this,
+									shell,
+									prefsBean.getStartDir(),
+									session);
 						case SAF:
 							return new SafSshFileSystemView(
-									getApplicationContext(),
-									Uri.parse(prefsBean.getSafUrl()),
-									getContentResolver(),
 									SshServerService.this,
+									Uri.parse(prefsBean.getSafUrl()),
 									session);
 						case RO_SAF:
 							return new RoSafSshFileSystemView(
-									Uri.parse(prefsBean.getSafUrl()),
-									getContentResolver(),
 									SshServerService.this,
+									Uri.parse(prefsBean.getSafUrl()),
 									session);
 						case VIRTUAL:
 							return new VirtualSshFileSystemView(
+									SshServerService.this,
 									new FsSshFileSystemView(
-											getApplicationContext(),
-											Uri.parse(prefsBean.getSafUrl()),
 											SshServerService.this,
+											Uri.parse(prefsBean.getSafUrl()),
 											prefsBean.getStartDir(),
 											session),
-									new RootSshFileSystemView(shell, SshServerService.this, prefsBean.getStartDir(), session),
-									new SafSshFileSystemView(
-											getApplicationContext(),
-											Uri.parse(prefsBean.getSafUrl()),
-											getContentResolver(),
+									new RootSshFileSystemView(
 											SshServerService.this,
+											shell,
+											prefsBean.getStartDir(),
+											session),
+									new SafSshFileSystemView(
+											SshServerService.this,
+											Uri.parse(prefsBean.getSafUrl()),
 											session),
 									new RoSafSshFileSystemView(
-											Uri.parse(prefsBean.getSafUrl()),
-											getContentResolver(),
 											SshServerService.this,
+											Uri.parse(prefsBean.getSafUrl()),
 											session),
-									SshServerService.this,
 									prefsBean.getStartDir(),
 									session
 							);


### PR DESCRIPTION
***Important: Root is not tested. It builds, there is no functional change in theory, but a quick test needed. I can't test root. The only functional changes:***
- ***create() is implemented with a copy-paste "touch" command, to be in sync with other implementations (FS, SAF) who do it for SSHFS***
- ***delete() also notifies MediaScanner, to be in sync with other implementations (FS)***

Tests are running (except root, I can't test it), Quick Share and Media Scanner tested manually on real Android 9 phone.

Changes:

### 1. remove file property "caching" (speed did not change)

- all "cached" properties become abstract in AbstractFile and got implemented in descendants
  - lastModified
  - size
  - readable
  - exists
  - isDirectory
- additionally some strange SCP (eg. #205) and SSHFS issues are caused exactly by this caching, because it is OK for "one-off" usage, but SCP and SSHFS reuse handles, ie. after calling eg. an mkdir() on a file, SCP calls a doesExist(), and without refreshing these cached values, they fail (in case of SSHFS I've added some cache update previously in SAF, that was hacky, and now got removed)
- only absPath and name remained in AbstractFile
  - they are used in nearly each log message, and at several other places
  - only move can change them, but in case of move, if we update these, we should update all other specific properties (file, bean, documentFile), but they are usually final, better not to go down this path, maybe later, if there is a real reason

### 2. File and FileSystemView (Fs, Root, QuickShare, Saf, RoSaf, Virtual) ctor/createFile/getFile simplification

- all FileSystemView class has PftpdService as first argument, all arguments that can be reached through PftpdService got removed (Context, ContentResolver, etc.)
  - created a new AbstractFileSystemView class for this pftpdService and logger properties
- all File class got a fileSystemView property, and a getFileSystemView() method, that handles the type properly in descendants (some Java generic magic)
  - this fileSystemView is the first argument in each ctor, all arguments that can be reached through fileSystemView (and PftpdService) got removed (Context, ContentResolver, StartUrl, etc.)
- added a public abstract boolean move(AbstractFile destination) to AbstractFile, it was missing, though we still need a wrapper in xxxFtpFile and xxxSshFile classes
  - implementations in FsFile and RootFile calls Utils.mediaScanFile on the old and new file name, to remove and add them
- reorganised the order of the method arguments in ctor/createFile/getFile methods to follow class hierarchy
- this way a lot of clutter got removed, it is so clean now what is where, how to access it, etc.
- plus some minor log changes (to log the return values (more) consistently)
  
### 3. mkdirs (note the 's' at the end) behavior in SAF

- in case of SAF if there is non-existent dirs in path for a new file, it's near impossible to create the file, we do not have the Uri for the nonexistent dirs, and there is no mkdirs() for DocumentFile
- this was an issue (or seemed to be) in #205, and an open issue in #372 and #373
- so SafFile in this case receives the list of the nonexistent parent folders, and creates them when needed (in mkdir() and in createOutputStream())
- this fixes #372 (SAF), but roSaf is still unchanged, I will do it when I return to make it RW
- the fun fact, that #205 got fixed with the cache removing above (SCP executes the necessary mkdir), but this fix is good for a direct SFTP file upload into a nonexistent dir

***Note: mkdirs got backported into FsFile.mkdir(), but in RootFile.mkdir() and RootFile.createOutputStream() I've added only comments, I can't test it, better not modify it.***

### 4. fix MediaScanner in FS an Root

- the original implementation never worked (see #336)
  - it used AsyncTask, but that can be used only on the UI thread
  - did not call execute() on it (it would do nothing on the background thread)
  - did not call connect() on the scanner connection, without this scanFile() would throw exception
- I refactored the functionality into a new class MediaScannerClient
  - it is instantiated and connected (without delay) in FS and Root FileSystemView ctor
  - it is used also in delete()
  - it uses only synchronize/wait/notifyAll
  - I've checked the Android source code about the implementation changes, it should work with all versions
  - tested on real Android 9 phone, uploaded/deleted FS images immediately appear/disappear from gallery

***Note: as mentioned above, not tested on rootFS, in theory it should work, the same code is running like under FS, but a quick manual test won't harm.***

---

The log that shows how 3. mkdirs works in SAF with SFTP
```
org.apache.sshd.server.sftp.SftpSubsystem                 Received SSH_FXP_OPEN (path=/saf/Test/dir/file.txt, pflags=26, attrs={})
org.primftpd.filesystem.VirtualSshFileSystemView          getFile '/saf/Test/dir/file.txt', absolute: '/saf/Test/dir/file.txt'
org.primftpd.filesystem.VirtualSshFileSystemView          Using SAF '/Test/dir/file.txt' for '/saf/Test/dir/file.txt'
org.primftpd.filesystem.SafSshFileSystemView              getFile(/Test/dir/file.txt), startUrl: content://com.android.externalstorage.documents/tree/17FB-0715%3A
org.primftpd.filesystem.SafSshFileSystemView                getFile(abs: /Test/dir/file.txt)
org.primftpd.filesystem.SafSshFileSystemView                  getFile(normalized: [Test, dir, file.txt])
org.primftpd.filesystem.SafSshFileSystemView                  building children uri for parent: 17FB-0715:
org.primftpd.filesystem.SafSshFileSystemView                  building children uri for parent: 17FB-0715:Test
org.primftpd.filesystem.SafSshFileSystemView                  calling createFile() for doc: file.txt, parentId: 17FB-0715:Test, parentUri: content://com.android.externalstorage.documents/tree/17FB-0715%3A/document/17FB-0715%3ATest, parentNonexistentDirs: /dir
--------------------------------------------------------------------------------------------------------------------v Utils.toPath() adds the extra '/', this is just in logging for the List<String>
org.primftpd.filesystem.SafSshFile                        new SafFile() with name 'file.txt', parent 'Test', dirs '/dir' and absPath '/Test/dir/file.txt'
org.primftpd.filesystem.SafSshFile                        [file.txt] getName()
org.primftpd.filesystem.SafSshFile                        [file.txt] getLastModified() -> 0
org.primftpd.filesystem.SafSshFile                        [file.txt] getSize() -> 0
org.primftpd.filesystem.SafSshFile                        [file.txt] isReadable() -> false
org.primftpd.filesystem.SafSshFile                        [file.txt] doesExist() -> false
org.primftpd.filesystem.SafSshFile                        [file.txt] isWritable() -> true
org.primftpd.filesystem.VirtualSshFile                    [file.txt] create()
org.primftpd.filesystem.SafSshFile                        [file.txt] create()
org.primftpd.filesystem.SafSshFile                        [file.txt] createNewFile()
---------------------------------------------------------------------v mkdirs() for SAF
org.primftpd.filesystem.SafSshFile                        [file.txt] creating parent folder, parent of parent: 'Test', parent: 'dir'
org.primftpd.filesystem.SafSshFile                        [file.txt] getLastModified() -> 1727639388000
org.primftpd.filesystem.SafSshFile                        [file.txt] isReadable() -> true
org.primftpd.filesystem.SafSshFile                        [file.txt] isWritable() -> true
org.primftpd.filesystem.VirtualSshFile                    [file.txt] truncate()
org.primftpd.filesystem.VirtualSshFile                    [file.txt] setAttributes()

```

The log that shows, that the 1. cache removing fixed SCP in #205
```
org.primftpd.filesystem.VirtualSshFileSystemView          getFile '/saf/Test/dir', absolute: '/saf/Test/dir'
org.primftpd.filesystem.VirtualSshFileSystemView          Using SAF '/Test/dir' for '/saf/Test/dir'
org.primftpd.filesystem.SafSshFileSystemView              getFile(/Test/dir), startUrl: content://com.android.externalstorage.documents/tree/17FB-0715%3A
org.primftpd.filesystem.SafSshFileSystemView                getFile(abs: /Test/dir)
org.primftpd.filesystem.SafSshFileSystemView                  getFile(normalized: [Test, dir])
org.primftpd.filesystem.SafSshFileSystemView                  building children uri for parent: 17FB-0715:
org.primftpd.filesystem.SafSshFileSystemView                  building children uri for parent: 17FB-0715:Test
org.primftpd.filesystem.SafSshFileSystemView                  calling createFile() for doc: dir, parentId: 17FB-0715:Test, parentUri: content://com.android.externalstorage.documents/tree/17FB-0715%3A/document/17FB-0715%3ATest
org.primftpd.filesystem.SafSshFile                        new SafFile() with name 'dir', parent 'Test', dirs '/' and absPath '/Test/dir'
org.primftpd.filesystem.SafSshFile                        [dir] getName()
org.primftpd.filesystem.SafSshFile                        [dir] getLastModified() -> 0
org.primftpd.filesystem.SafSshFile                        [dir] getSize() -> 0
org.primftpd.filesystem.SafSshFile                        [dir] isReadable() -> false
org.primftpd.filesystem.SafSshFile                        [dir] doesExist() -> false
----------------------------------------------------------------v SCP creates the parent dir
org.primftpd.filesystem.SafSshFile                        [dir] mkdir()
org.primftpd.filesystem.SafSshFile                        [dir] getAbsolutePath() -> '/Test/dir'
org.primftpd.services.SshServerService                    posting ClientActionEvent: ClientActionEvent{storage=SAF, protocol=SFTP, timestamp=Sun Sep 29 21:57:50 GMT+02:00 2024, clientIp='127.0.0.1', clientAction=CREATE_DIR, path='/Test/dir'}
org.apache.sshd.server.channel.ChannelSession             OUT: 00
org.apache.sshd.common.channel.Window                     Consume server remote window by 1 down to 2097150
org.apache.sshd.server.channel.ChannelSession             Send SSH_MSG_CHANNEL_DATA on channel 0
org.apache.sshd.server.session.ServerSession              Sending packet #11: 5e 00 00 00 00 00 00 00 01 00
org.apache.sshd.server.session.ServerSession              Received packet #12: 5e 00 00 00 00 00 00 00 13 43 30 36 36 36 20 35 20 66 69 6c 65 2d 61 2e 74 78 74 0a
org.apache.sshd.server.channel.ChannelSession             Received SSH_MSG_CHANNEL_DATA on channel ChannelSession[id=0, recipient=0]
org.apache.sshd.server.channel.ChannelSession             Received channel data: 43 30 36 36 36 20 35 20 66 69 6c 65 2d 61 2e 74 78 74 0a
org.apache.sshd.server.channel.PipeDataReceiver           IN:  43 30 36 36 36 20 35 20 66 69 6c 65 2d 61 2e 74 78 74 0a
...                                                       ...
org.apache.sshd.common.scp.ScpHelper                      Received header: C0666 5 file-a.txt
org.apache.sshd.common.scp.ScpHelper                      Receiving file org.primftpd.filesystem.VirtualSshFile@ccdd6d7
----------------------------------------------------------------v The value of 'exists' is modified in SafFile after cache removed, and VirtFile also returns this from SafFile (SCP reuses the [dir] SafFile)
org.primftpd.filesystem.SafSshFile                        [dir] doesExist() -> true
org.primftpd.filesystem.SafSshFile                        [dir] isDirectory() -> true
org.primftpd.filesystem.VirtualSshFile                    [dir] getAbsolutePath() -> '/saf/Test/dir'
org.primftpd.filesystem.VirtualSshFileSystemView          getFile(baseDir: /saf/Test/dir, file: file-a.txt)
org.primftpd.filesystem.VirtualSshFile                    [dir] getAbsolutePath() -> '/saf/Test/dir'
org.primftpd.filesystem.VirtualSshFileSystemView          getFile '/saf/Test/dir/file-a.txt', absolute: '/saf/Test/dir/file-a.txt'
org.primftpd.filesystem.VirtualSshFileSystemView          Using SAF '/Test/dir/file-a.txt' for '/saf/Test/dir/file-a.txt'
org.primftpd.filesystem.SafSshFileSystemView              getFile(/Test/dir/file-a.txt), startUrl: content://com.android.externalstorage.documents/tree/17FB-0715%3A
org.primftpd.filesystem.SafSshFileSystemView                getFile(abs: /Test/dir/file-a.txt)
org.primftpd.filesystem.SafSshFileSystemView                  getFile(normalized: [Test, dir, file-a.txt])
org.primftpd.filesystem.SafSshFileSystemView                  building children uri for parent: 17FB-0715:
org.primftpd.filesystem.SafSshFileSystemView                  building children uri for parent: 17FB-0715:Test
org.primftpd.filesystem.SafSshFileSystemView                  building children uri for parent: 17FB-0715:Test/dir
org.primftpd.filesystem.SafSshFileSystemView                  calling createFile() for doc: file-a.txt, parentId: 17FB-0715:Test/dir, parentUri: content://com.android.externalstorage.documents/tree/17FB-0715%3A/document/17FB-0715%3ATest%2Fdir
-------------------------------------------------------------------------------------------------------v Exists when scp starts to copy the file
org.primftpd.filesystem.SafSshFile                        new SafFile() with name 'file-a.txt', parent 'dir', dirs '/' and absPath '/Test/dir/file-a.txt'
org.primftpd.filesystem.SafSshFile                        [file-a.txt] getName()
org.primftpd.filesystem.SafSshFile                        [file-a.txt] getLastModified() -> 0
org.primftpd.filesystem.SafSshFile                        [file-a.txt] getSize() -> 0
org.primftpd.filesystem.SafSshFile                        [file-a.txt] isReadable() -> false
org.primftpd.filesystem.SafSshFile                        [file-a.txt] doesExist() -> false
org.primftpd.filesystem.SafSshFile                        [file-a.txt] doesExist() -> false
org.primftpd.filesystem.SafSshFile                        [file-a.txt] doesExist() -> false
org.primftpd.filesystem.SafSshFile                        [file-a.txt] createOutputStream(offset: 0)
org.primftpd.filesystem.SafSshFile                        [file-a.txt] getAbsolutePath() -> '/Test/dir/file-a.txt'
org.primftpd.services.SshServerService                    posting ClientActionEvent: ClientActionEvent{storage=SAF, protocol=SFTP, timestamp=Sun Sep 29 21:57:50 GMT+02:00 2024, clientIp='127.0.0.1', clientAction=UPLOAD, path='/Test/dir/file-a.txt'}
org.primftpd.filesystem.SafSshFile                        [file-a.txt] createNewFile()
org.primftpd.filesystem.SafSshFile                           createOutputStream() uri: content://com.android.externalstorage.documents/tree/17FB-0715%3A/document/17FB-0715%3ATest%2Fdir%2Ffile-a.txt
```

The log that shows how 4. MediaScanner works in FS
```
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:40:51 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=UPLOAD, path='/storage/emulated/0/Download/20240625_174813.jpg.filepart'}
org.primftpd.filesystem.MediaScannerClient                 media scanning started for file '/storage/emulated/0/Download/20240625_174813.jpg.filepart'
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:40:51 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=RENAME, path='/storage/emulated/0/Download/20240625_174813.jpg.filepart'}
org.primftpd.filesystem.MediaScannerClient                 media scanning started for file '/storage/emulated/0/Download/20240625_174813.jpg.filepart'
org.primftpd.filesystem.MediaScannerClient                 media scanning started for file '/storage/emulated/0/Download/20240625_174813.jpg'
org.primftpd.filesystem.MediaScannerClient                 media scanning completed for file '/storage/emulated/0/Download/20240625_174813.jpg.filepart'
org.primftpd.filesystem.MediaScannerClient                 media scanning completed for file '/storage/emulated/0/Download/20240625_174813.jpg.filepart'
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:40:51 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=LIST_DIR, path='/storage/emulated/0/Download'}
org.primftpd.filesystem.MediaScannerClient                 media scanning completed for file '/storage/emulated/0/Download/20240625_174813.jpg'
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:41:12 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=RENAME, path='/storage/emulated/0/Download/20240625_174813.jpg'}
org.primftpd.filesystem.MediaScannerClient                 media scanning started for file '/storage/emulated/0/Download/20240625_174813.jpg'
org.primftpd.filesystem.MediaScannerClient                 media scanning started for file '/storage/emulated/0/Documents/20240625_174813.jpg'
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:41:12 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=LIST_DIR, path='/storage/emulated/0/Download'}
org.primftpd.filesystem.MediaScannerClient                 media scanning completed for file '/storage/emulated/0/Download/20240625_174813.jpg'
org.primftpd.filesystem.MediaScannerClient                 media scanning completed for file '/storage/emulated/0/Documents/20240625_174813.jpg'
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:41:18 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=LIST_DIR, path='/storage/emulated/0/Documents'}
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:41:23 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=DELETE, path='/storage/emulated/0/Documents/20240625_174813.jpg'}
org.primftpd.filesystem.MediaScannerClient                 media scanning started for file '/storage/emulated/0/Documents/20240625_174813.jpg'
org.primftpd.services.SshServerService                     posting ClientActionEvent: ClientActionEvent{storage=FS, protocol=SFTP, timestamp=Sat Oct 05 21:41:23 GMT+02:00 2024, clientIp='192.168.1.122', clientAction=LIST_DIR, path='/storage/emulated/0/Documents'}
org.primftpd.filesystem.MediaScannerClient                 media scanning completed for file '/storage/emulated/0/Documents/20240625_174813.jpg'
```
