### PR TITLE
Remove poFS dependence on SAF (because of time resolution)

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFileSystemView.java
@@ -1,7 +1,9 @@
 package org.primftpd.filesystem;
 
-import android.net.Uri;
 import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.primftpd.services.PftpdService;
 
 public abstract class FsFileSystemView<
@@ -9,31 +11,34 @@ public abstract class FsFileSystemView<
 		extends AbstractFileSystemView {
 
 	private final MediaScannerClient mediaScannerClient;
-	private final String safVolumePath;
-	private final int safTimeResolution;
 
 	protected abstract TFile createFile(File file);
 
 	protected abstract String absolute(String file);
 
-	public FsFileSystemView(PftpdService pftpdService, Uri safStartUrl) {
+	public FsFileSystemView(PftpdService pftpdService) {
 		super(pftpdService);
 		this.mediaScannerClient = new MediaScannerClient(pftpdService.getContext());
-		// FS should not have some relation to SAF
-		// But to workaround Amdroid issues with lastModifiedTimestamps it is required anyway
-		this.safTimeResolution = StorageManagerUtil.getFilesystemTimeResolutionForTreeUri(safStartUrl);
-		this.safVolumePath = safTimeResolution != 1
-				? StorageManagerUtil.getVolumePathFromTreeUri(safStartUrl, pftpdService.getContext())
-				: null;
 	}
 
 	public final MediaScannerClient getMediaScannerClient() {
 		return mediaScannerClient;
 	}
 
+	private final static Pattern getVolumeIdRegex;
+	static {
+		getVolumeIdRegex = Pattern.compile("^\\/storage\\/([\\dA-F]{4}-[\\dA-F]{4})");
+	}
+
 	public long getCorrectedTime(String abs, long time) {
-		int timeResolution = safVolumePath != null && abs.startsWith(safVolumePath) ? safTimeResolution : 1;
-		return (time / timeResolution) * timeResolution;
+		Matcher matcher = getVolumeIdRegex.matcher(abs);
+		if (matcher.matches()) {
+			String volumeId = matcher.group(1);
+			int timeResolution = StorageManagerUtil.getFilesystemTimeResolutionForVolumeId(volumeId);
+			return (time / timeResolution) * timeResolution;
+		} else {
+			return time;
+		}
 	}
 
 	public TFile getFile(String file) {

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFtpFileSystemView.java
@@ -1,7 +1,5 @@
 package org.primftpd.filesystem;
 
-import android.net.Uri;
-
 import org.apache.ftpserver.ftplet.FileSystemView;
 import org.apache.ftpserver.ftplet.FtpFile;
 import org.apache.ftpserver.ftplet.User;
@@ -16,8 +14,8 @@ public class FsFtpFileSystemView extends FsFileSystemView<FsFtpFile, FtpFile> im
 
 	private FsFtpFile workingDir;
 
-	public FsFtpFileSystemView(PftpdService pftpdService, Uri safStartUrl, File homeDir, User user) {
-		super(pftpdService, safStartUrl);
+	public FsFtpFileSystemView(PftpdService pftpdService, File homeDir, User user) {
+		super(pftpdService);
 		this.homeDir = homeDir;
 		this.user = user;
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFileSystemView.java
@@ -1,7 +1,5 @@
 package org.primftpd.filesystem;
 
-import android.net.Uri;
-
 import org.apache.sshd.common.Session;
 import org.apache.sshd.common.file.FileSystemView;
 import org.apache.sshd.common.file.SshFile;
@@ -14,8 +12,8 @@ public class FsSshFileSystemView extends FsFileSystemView<FsSshFile, SshFile> im
 	private final File homeDir;
 	private final Session session;
 
-	public FsSshFileSystemView(PftpdService pftpdService, Uri safStartUrl, File homeDir, Session session) {
-		super(pftpdService, safStartUrl);
+	public FsSshFileSystemView(PftpdService pftpdService, File homeDir, Session session) {
+		super(pftpdService);
 		this.homeDir = homeDir;
 		this.session = session;
 	}

--- a/primitiveFTPd/src/org/primftpd/filesystem/StorageManagerUtil.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/StorageManagerUtil.java
@@ -68,6 +68,11 @@ public final class StorageManagerUtil {
         return volumePath;
     }
 
+    public static int getFilesystemTimeResolutionForTreeUri(Uri startUrl) {
+        String volumeId = getVolumeIdFromTreeUri(startUrl);
+        return getFilesystemTimeResolutionForVolumeId(volumeId);
+    }
+
     private final static Map<String, Integer> CACHED_FILESYSTEM_TIME_RESOLUTIONS = new HashMap<>();
 
     /**
@@ -81,13 +86,12 @@ public final class StorageManagerUtil {
      *    the used sdcardfs has another bug, it provides the same 2s resolution even for the exfat file-system,
      *    so in this case we have to modify the resolution even for the exfat file-system to 2s.
      *
-     * @param  startUrl SAF startUrl
-     * @return          SAF file system's time resolution measured in milliseconds
+     * @param  volumeId volume id, eg. "1234-ABCD"
+     * @return          file system's time resolution measured in milliseconds
      */
-    public static int getFilesystemTimeResolutionForTreeUri(Uri startUrl) {
-        LOGGER.trace("getFilesystemTimeResolutionForTreeUri({})", startUrl);
+    public static int getFilesystemTimeResolutionForVolumeId(String volumeId) {
+        LOGGER.trace("getFilesystemTimeResolutionForVolumeId({})", volumeId);
         int timeResolution = 1; // use 1ms by default
-        String volumeId = getVolumeIdFromTreeUri(startUrl);
         if (volumeId != null) {
             Integer cachedTimeResolution = CACHED_FILESYSTEM_TIME_RESOLUTIONS.get(volumeId);
             if (cachedTimeResolution != null) {
@@ -151,11 +155,11 @@ public final class StorageManagerUtil {
                     timeResolution = Math.max(timeResolution, Math.max(mediaTimeResolution, storageTimeResolution));
                     CACHED_FILESYSTEM_TIME_RESOLUTIONS.put(volumeId, timeResolution);
                 } catch (Exception e) {
-                    LOGGER.error("getFilesystemTimeResolutionForTreeUri()", e);
+                    LOGGER.error("getFilesystemTimeResolutionForVolumeId()", e);
                 }
             }
         }
-        LOGGER.trace("  getFilesystemTimeResolutionForTreeUri({}) -> {}", startUrl, timeResolution);
+        LOGGER.trace("  getFilesystemTimeResolutionForVolumeId({}) -> {}", volumeId, timeResolution);
         return timeResolution;
     }
 

--- a/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/FtpServerService.java
@@ -113,7 +113,6 @@ public class FtpServerService extends AbstractServerService
 					case PLAIN:
 						return new FsFtpFileSystemView(
 								FtpServerService.this,
-								Uri.parse(prefsBean.getSafUrl()),
 								prefsBean.getStartDir(),
 								user);
 					case ROOT:
@@ -137,7 +136,6 @@ public class FtpServerService extends AbstractServerService
 								FtpServerService.this,
 								new FsFtpFileSystemView(
 										FtpServerService.this,
-										Uri.parse(prefsBean.getSafUrl()),
 										prefsBean.getStartDir(),
 										user),
 								new RootFtpFileSystemView(

--- a/primitiveFTPd/src/org/primftpd/services/SshServerService.java
+++ b/primitiveFTPd/src/org/primftpd/services/SshServerService.java
@@ -193,7 +193,6 @@ public class SshServerService extends AbstractServerService
 					case PLAIN:
 						return new FsSshFileSystemView(
 								SshServerService.this,
-								Uri.parse(prefsBean.getSafUrl()),
 								prefsBean.getStartDir(),
 								session);
 					case ROOT:
@@ -217,7 +216,6 @@ public class SshServerService extends AbstractServerService
 								SshServerService.this,
 								new FsSshFileSystemView(
 										SshServerService.this,
-										Uri.parse(prefsBean.getSafUrl()),
 										prefsBean.getStartDir(),
 										session),
 								new RootSshFileSystemView(


### PR DESCRIPTION
In #360 I introduced a hacky solution for poFS to show the same time resolution as the "fixed" SAF, and none of us liked it, because plain old FS got a dependence on SAF.

Now I remove the dependence:
- poFS checks each path whether it starts with '/storage/' and continues with 'XXXX-XXXX' (this is checked with a precompiled regex), then calls StorageManagerUtil to get the time resolution for the volumeId
- and StorageManagerUtil answers the questions already from a cache, so everything should be fast

Note: I had a version, where a precompiled regex did everything, it worked on any regex tester (even on ICU4C-s tester that is used by Android, at least in theory), worked on Android emulator, but didn't work on real phones. It's unbeliavable how broken Android is...