### PR TITLE
Fix SSH truncate

### DIFF
--- a/primitiveFTPd/src/org/primftpd/filesystem/AbstractFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/AbstractFile.java
@@ -125,8 +125,7 @@ public abstract class AbstractFile<TFileSystemView extends AbstractFileSystemVie
         logger.trace("[{}] handleClose()", name);
     }
 
-    public void truncate() {
-        // TODO ssh truncate
+    public void truncate() throws IOException {
         logger.trace("[{}] truncate()", name);
     }
 

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsFile.java
@@ -225,7 +225,12 @@ public abstract class FsFile<TMina, TFileSystemView extends FsFileSystemView>
 	}
 
 	public OutputStream createOutputStream(long offset) throws IOException {
-		logger.trace("[{}] createOutputStream({})", name, offset);
+		logger.trace("[{}] createOutputStream(offset: {}), file: {}",
+				new Object []{
+						name,
+						offset,
+						file.getAbsolutePath()
+		});
 		postClientAction(ClientActionEvent.ClientAction.UPLOAD);
 
 		// may be necessary to create dirs
@@ -269,7 +274,7 @@ public abstract class FsFile<TMina, TFileSystemView extends FsFileSystemView>
 	}
 
 	public InputStream createInputStream(long offset) throws IOException {
-		logger.trace("[{}] createInputStream(), offset: {}, file: {}",
+		logger.trace("[{}] createInputStream(offset: {}), file: {}",
 				new Object []{
 						name,
 						offset,

--- a/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/FsSshFile.java
@@ -4,7 +4,9 @@ import org.apache.sshd.common.Session;
 import org.apache.sshd.common.file.SshFile;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.util.List;
 
 public class FsSshFile extends FsFile<SshFile, FsSshFileSystemView> implements SshFile {
@@ -37,9 +39,17 @@ public class FsSshFile extends FsFile<SshFile, FsSshFileSystemView> implements S
 	}
 
 	@Override
+	public void truncate() throws IOException {
+		logger.trace("[{}] truncate()", name);
+		try (FileChannel outChannel = new FileOutputStream(file, true).getChannel()) {
+			outChannel.truncate(0);
+		}
+	}
+
+	@Override
 	public boolean create() throws IOException {
-        // This call is required by SSHFS, because it calls STAT on created new files.
-        // This call is not required by normal clients who simply open, write and close the file.
+		// This call is required by SSHFS, because it calls STAT on created new files.
+		// This call is not required by normal clients who simply open, write and close the file.
 		boolean result = file.createNewFile();
 		logger.trace("[{}] create() -> {}", name, result);
 		return result;

--- a/primitiveFTPd/src/org/primftpd/filesystem/QuickShareSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/QuickShareSshFile.java
@@ -4,6 +4,7 @@ import org.apache.sshd.common.Session;
 import org.apache.sshd.common.file.SshFile;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 public class QuickShareSshFile extends QuickShareFile<SshFile, QuickShareSshFileSystemView> implements SshFile {
@@ -43,6 +44,12 @@ public class QuickShareSshFile extends QuickShareFile<SshFile, QuickShareSshFile
     public String getOwner() {
         logger.trace("[{}] getOwner()", name);
         return session.getUsername();
+    }
+
+    @Override
+    public void truncate() throws IOException {
+        logger.trace("[{}] truncate()", name);
+        throw new IOException(String.format("Can not truncate file '%s'", absPath));
     }
 
     @Override

--- a/primitiveFTPd/src/org/primftpd/filesystem/RootSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/RootSshFile.java
@@ -116,6 +116,12 @@ public class RootSshFile extends RootFile<SshFile, RootSshFileSystemView> implem
     }
 
     @Override
+    public void truncate() {
+        boolean result = runCommand("truncate -c -s 0" + " " + escapePath(absPath));
+        logger.trace("[{}] truncate() -> {}", name, result);
+    }
+
+    @Override
     public boolean create() throws IOException {
         // This call is required by SSHFS, because it calls STAT on created new files.
         // This call is not required by normal clients who simply open, write and close the file.

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafFile.java
@@ -39,7 +39,7 @@ public abstract class SafFile<TMina, TFileSystemView extends SafFileSystemView> 
 
     private DocumentFile parentDocumentFile;
     private List<String> parentNonexistentDirs;
-    private DocumentFile documentFile;
+    protected DocumentFile documentFile;
 
     public SafFile(
             TFileSystemView fileSystemView,

--- a/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/SafSshFile.java
@@ -58,6 +58,15 @@ public class SafSshFile extends SafFile<SshFile, SafSshFileSystemView> implement
     }
 
     @Override
+    public void truncate() throws IOException {
+        logger.trace("[{}] truncate()", name);
+        if (documentFile != null) {
+            // We can't use "wt" in SafFile.createOutputStream(), in case of zero new size, no output stream will be created.
+            getPftpdService().getContext().getContentResolver().openOutputStream(documentFile.getUri(), "wt").close();
+        }
+    }
+
+    @Override
     public boolean create() throws IOException {
         // This call is required by SSHFS, because it calls STAT on created new files.
         // This call is not required by normal clients who simply open, write and close the file.

--- a/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
+++ b/primitiveFTPd/src/org/primftpd/filesystem/VirtualSshFile.java
@@ -52,6 +52,14 @@ public class VirtualSshFile extends VirtualFile<SshFile, VirtualSshFileSystemVie
     }
 
     @Override
+    public void truncate() throws IOException {
+        logger.trace("[{}] truncate()", name);
+        if (delegate != null) {
+            ((SshFile) delegate).truncate();
+        }
+    }
+
+    @Override
     public boolean create() throws IOException {
         // This call is required by SSHFS, because it calls STAT on created new files.
         // This call is not required by normal clients who simply open, write and close the file.

--- a/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
+++ b/sshd-core-0.14.0/src/org/apache/sshd/server/sftp/SftpSubsystem.java
@@ -106,7 +106,7 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
         public ExecutorService getExecutorService() {
         	return executors;
         }
-        
+
         public boolean isShutdownOnExit() {
         	return shutdownExecutor;
         }
@@ -514,6 +514,13 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
                             sendStatus(id, SSH_FX_FAILURE, path);
                             return;
                         }
+                        if ((pflags & SSH_FXF_TRUNC) != 0) {
+                            if (!file.isWritable()) {
+                                sendStatus(id, SSH_FX_PERMISSION_DENIED, "Can not truncate " + path);
+                                return;
+                            }
+                            file.truncate();
+                        }
                     } else {
                         if (((pflags & SSH_FXF_CREAT) != 0)) {
                             if (!file.isWritable()) {
@@ -528,13 +535,6 @@ public class SftpSubsystem implements Command, Runnable, SessionAware, FileSyste
                             sendStatus(id, SSH_FX_NO_SUCH_FILE, "No such file " + path);
                             return;
                         }
-                    }
-                    if ((pflags & SSH_FXF_TRUNC) != 0) {
-                        if (!file.isWritable()) {
-                            sendStatus(id, SSH_FX_PERMISSION_DENIED, "Can not truncate " + path);
-                            return;
-                        }
-                        file.truncate();
                     }
                     if ((pflags & SSH_FXF_CREAT) != 0) {
                         file.setAttributes(attrs);


### PR DESCRIPTION
Fixes #420

I copy my comment from the issue.

---

I've made tests, I can partially reproduce the issue, but fixed the bug I've found.

Tested: Android 9, WinSCP, my forked pftpd (but this contains no relevant changes compared to the latest "official" pftpd)

I've tested overwriting with shorter and zero length file, with SFTP and FTP, with plain old FS, SAF and Virtual. Root, QuickShare and roSAF are not tested.

Results:
- FTP has no issues with anything.
- SFTP has issue with zero length overwrite (both FS and SAF).

Reason:
- In case of writing a zero length file, FTP always starts a STOR that calls createOutputStream() and closing that will truncate the length to the written length, shorter or zero.
- SFTP differs, that it can explicitly truncate a file when opens it with OPEN, but in case of writing a zero length file, SFTP will not call WRITE and will not call createOutputStream().
- But SFTP/SSH truncate wasn't implemented. :D "// TODO ssh truncate" in AbstractFile.java And this caused that a zero length overwrite left the file unchanged.

Fix:
- I've implemented it in case of FS, SAF, ROOT, QuickShare, Virtual.
  - FS, SAF and Virtual are tested, works.
  - ROOT is tested only with adb shell, the command `truncate -c -s 0 ...` works, but not tested with rooted phone and pftpd, I have no rooted phone.
  - QuickShare just throws an exception, it shouldn't get there, so I even didn't try to test it.
- I didn't touch roSAF, it is read only.

Notes:
- This solution has a small performance hit in case of SFTP and non-zero-length overwrite, because it will truncate the file first, even if it will be overwritten and truncated immediately. But there is no way to skip truncate in OPEN, the new file size is not a mandatory attribute of the OPEN SSH command.
- I haven't tested createOutputStream with non-zero offset, this is possible only in case of FS.