### PR TITLE
GitHub 437

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidxAppcompat = "1.7.1"
 androidxCoordinatorlayout = "1.3.0"
 androidxDocumentfile = "1.1.0"
 androidxFragment = "1.8.9"
+androidxLifecycle = "2.10.0"
 androidxPreference = "1.2.1"
 androidxRecyclerview = "1.4.0"
 
@@ -38,6 +39,8 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-coordinatorlayout = { group = "androidx.coordinatorlayout", name = "coordinatorlayout", version.ref = "androidxCoordinatorlayout" }
 androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "androidxDocumentfile" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragment" }
+androidx-lifecycle-livedata = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
 androidx-preference = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreference" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidxRecyclerview" }
 

--- a/primitiveFTPd/build.gradle
+++ b/primitiveFTPd/build.gradle
@@ -91,6 +91,8 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.documentfile)
     implementation(libs.androidx.fragment)
+    implementation(libs.androidx.lifecycle.livedata)
+    implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.preference)
     implementation(libs.androidx.recyclerview)
 

--- a/primitiveFTPd/src/org/primftpd/ui/AddPubkeyAuthKeyDialogFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/AddPubkeyAuthKeyDialogFragment.java
@@ -6,18 +6,28 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.primftpd.R;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProvider;
 
 public class AddPubkeyAuthKeyDialogFragment extends DialogFragment {
 
-    protected final PubKeyAuthKeysFragment fragment;
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public AddPubkeyAuthKeyDialogFragment(PubKeyAuthKeysFragment fragment) {
-        this.fragment = fragment;
+    private SharedViewModel vm;
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        vm = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     }
 
     @Override
@@ -33,7 +43,10 @@ public class AddPubkeyAuthKeyDialogFragment extends DialogFragment {
         builder.setPositiveButton(R.string.add, (dialog, id) -> {
             TextView textbox = view.findViewById(R.id.addPubkeyTextbox);
             CharSequence key = textbox.getText();
-            fragment.addKeyToFile(key);
+            String msg = vm.addKeyToFile(view.getContext(), key, logger);
+            if (msg != null) {
+                Toast.makeText(view.getContext(), msg, Toast.LENGTH_SHORT).show();
+            }
         });
         builder.setNegativeButton(R.string.cancel, (dialog, id) -> {
             // nothing

--- a/primitiveFTPd/src/org/primftpd/ui/GenKeysAskDialogFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/GenKeysAskDialogFragment.java
@@ -20,7 +20,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProvider;
 
 public class GenKeysAskDialogFragment extends DialogFragment {
     public static final String KEY_START_SERVER = "START_SERVER";
@@ -29,11 +31,15 @@ public class GenKeysAskDialogFragment extends DialogFragment {
 
     private boolean startServerOnFinish;
 
-    private final PftpdFragment pftpdFragment;
+    private SharedViewModel vm;
 
-    public GenKeysAskDialogFragment(PftpdFragment pftpdFragment) {
-        this.pftpdFragment = pftpdFragment;
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        vm = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     }
+
     @Override
     public void setArguments(Bundle args) {
         super.setArguments(args);
@@ -64,7 +70,7 @@ public class GenKeysAskDialogFragment extends DialogFragment {
             return;
         }
 
-        KeyFingerprintProvider keyFingerprintProvider = pftpdFragment.getKeyFingerprintProvider();
+        KeyFingerprintProvider keyFingerprintProvider = vm.getKeyFingerprintProvider();
 
         // run in background to not block UI
         // note: in previous versions a progress dialog was shown here
@@ -109,11 +115,15 @@ public class GenKeysAskDialogFragment extends DialogFragment {
         // clean up
         // update UI in UI thread
         keyFingerprintProvider.calcPubkeyFingerprints(ctxt);
-        pftpdFragment.showKeyFingerprints();
+        vm.updateKeyFingerprints();
 
         if (startServerOnFinish) {
             // icon members should be set at this time
-            ServicesStartStopUtil.startServers(pftpdFragment);
+            ServicesStartStopUtil.startServers(getContext(),
+                                               requireActivity().getSupportFragmentManager(),
+                                               vm.getChosenIp(),
+                                               vm.getKeyFingerprintProvider(),
+                                               null);
         }
     }
 }

--- a/primitiveFTPd/src/org/primftpd/ui/LeanbackActivity.java
+++ b/primitiveFTPd/src/org/primftpd/ui/LeanbackActivity.java
@@ -1,9 +1,17 @@
 package org.primftpd.ui;
 
 
+import android.os.Bundle;
 import android.view.Menu;
 
 public class LeanbackActivity extends MainTabsActivity {
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        vm.setLeanBack(true);
+    }
 
     @Override
     protected PftpdFragment createPftpdFragment() {
@@ -13,11 +21,6 @@ public class LeanbackActivity extends MainTabsActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // no menu for leanback
-        return true;
-    }
-
-    @Override
-    protected boolean isLeanback() {
         return true;
     }
 }

--- a/primitiveFTPd/src/org/primftpd/ui/LeanbackFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/LeanbackFragment.java
@@ -33,7 +33,12 @@ public class LeanbackFragment extends PftpdFragment {
                         if (serversRunningBean.atLeastOneRunning()) {
                             ServicesStartStopUtil.stopServers(ctxt);
                         } else {
-                            ServicesStartStopUtil.startServers(this);
+                            ServicesStartStopUtil.startServers(
+                                    getContext(),
+                                    requireActivity().getSupportFragmentManager(),
+                                    vm.getChosenIp(),
+                                    vm.getKeyFingerprintProvider(),
+                                    vm.getPrefsBean());
                         }
                     });
         }

--- a/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
+++ b/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
@@ -48,8 +48,6 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
     protected MenuItem startIcon;
     protected MenuItem stopIcon;
 
-    protected PftpdFragment pftpdFragment;
-    protected QrFragment qrFragment;
     private MainAdapter adapter;
     SharedViewModel vm;
 
@@ -92,10 +90,8 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
         vm = new ViewModelProvider(this).get(SharedViewModel.class);
         vm.init(this, logger);
 
-        this.pftpdFragment = createPftpdFragment();
-        this.qrFragment = new QrFragment();
-        adapter.addFragment(pftpdFragment);
-        adapter.addFragment(qrFragment);
+        adapter.addFragment(createPftpdFragment());
+        adapter.addFragment(new QrFragment());
         adapter.addFragment(new CleanSpaceFragment());
         adapter.addFragment(new ClientActionFragment());
         adapter.addFragment(new KeysFingerprintsFragment());
@@ -118,7 +114,7 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
                 if (tabCharSeq != null) {
                     String tabText = tabCharSeq.toString();
                     if (TAB_NAME_QR.equals(tabText)) {
-                        qrFragment.drawIfChanged();
+                        vm.updateQrCode();
                     }
                 }
             }

--- a/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
+++ b/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
@@ -35,6 +35,7 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.viewpager.widget.ViewPager;
 
 public class MainTabsActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -50,6 +51,7 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
     protected PftpdFragment pftpdFragment;
     protected QrFragment qrFragment;
     private MainAdapter adapter;
+    SharedViewModel vm;
 
     protected PftpdFragment createPftpdFragment() {
         return new PftpdFragment();
@@ -87,15 +89,18 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
         adapter = new MainAdapter(getSupportFragmentManager());
         viewPager.setAdapter(adapter);
 
+        vm = new ViewModelProvider(this).get(SharedViewModel.class);
+        vm.init(this, logger);
+
         this.pftpdFragment = createPftpdFragment();
-        this.qrFragment = new QrFragment(pftpdFragment);
+        this.qrFragment = new QrFragment();
         adapter.addFragment(pftpdFragment);
         adapter.addFragment(qrFragment);
         adapter.addFragment(new CleanSpaceFragment());
         adapter.addFragment(new ClientActionFragment());
         adapter.addFragment(new KeysFingerprintsFragment());
         INDEX_FINGERPRINTS = adapter.getCount() - 1;
-        adapter.addFragment(new PubKeyAuthKeysFragment(isLeanback()));
+        adapter.addFragment(new PubKeyAuthKeysFragment());
         adapter.addFragment(new FtpPrefsFragment());
         adapter.addFragment(new AboutFragment());
         updateTabNames();
@@ -124,10 +129,6 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
             public void onTabReselected(TabLayout.Tab tab) {
             }
         });
-    }
-
-    protected boolean isLeanback() {
-        return false;
     }
 
     @Override
@@ -268,7 +269,11 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
     public void handleStart() {
         logger.trace("handleStart()");
 
-        ServicesStartStopUtil.startServers(pftpdFragment);
+        ServicesStartStopUtil.startServers(this,
+                                           getSupportFragmentManager(),
+                                           vm.getChosenIp(),
+                                           vm.getKeyFingerprintProvider(),
+                                           vm.getPrefsBean());
     }
 
     protected void handleStop() {
@@ -298,7 +303,7 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
             updateTabNames();
         }
         if (LoadPrefsUtil.PREF_KEY_HOSTKEY_ALGOS.equals(key)) {
-            GenKeysAskDialogFragment askDiag = new GenKeysAskDialogFragment(pftpdFragment);
+            GenKeysAskDialogFragment askDiag = new GenKeysAskDialogFragment();
             askDiag.show(getSupportFragmentManager(), PftpdFragment.DIALOG_TAG);
         }
     }

--- a/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
+++ b/primitiveFTPd/src/org/primftpd/ui/MainTabsActivity.java
@@ -40,7 +40,6 @@ import androidx.viewpager.widget.ViewPager;
 
 public class MainTabsActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
 
-    protected static int INDEX_FINGERPRINTS = 0;
     protected static final String TAB_NAME_MAIN_UI = "pftpd";
     protected static final String TAB_NAME_QR = "QR";
     private Logger logger = LoggerFactory.getLogger(getClass());
@@ -95,7 +94,7 @@ public class MainTabsActivity extends AppCompatActivity implements SharedPrefere
         adapter.addFragment(new CleanSpaceFragment());
         adapter.addFragment(new ClientActionFragment());
         adapter.addFragment(new KeysFingerprintsFragment());
-        INDEX_FINGERPRINTS = adapter.getCount() - 1;
+        vm.setFingerprintsFragmentTabIndex(adapter.getCount() - 1);
         adapter.addFragment(new PubKeyAuthKeysFragment());
         adapter.addFragment(new FtpPrefsFragment());
         adapter.addFragment(new AboutFragment());

--- a/primitiveFTPd/src/org/primftpd/ui/PftpdFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/PftpdFragment.java
@@ -48,12 +48,10 @@ import org.primftpd.events.ServerInfoRequestEvent;
 import org.primftpd.events.ServerInfoResponseEvent;
 import org.primftpd.events.ServerStateChangedEvent;
 import org.primftpd.prefs.LoadPrefsUtil;
-import org.primftpd.prefs.PrefsBean;
 import org.primftpd.prefs.StorageType;
 import org.primftpd.util.IpAddressBean;
 import org.primftpd.util.IpAddressProvider;
 import org.primftpd.util.KeyFingerprintBean;
-import org.primftpd.util.KeyFingerprintProvider;
 import org.primftpd.util.SampleAuthKeysFileCreator;
 import org.primftpd.util.ServersRunningBean;
 import org.primftpd.util.ServicesStartStopUtil;
@@ -70,9 +68,11 @@ import java.util.concurrent.Executors;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModelProvider;
 
 public class PftpdFragment extends Fragment implements RecreateLogger, RadioGroup.OnCheckedChangeListener {
 
@@ -92,9 +92,8 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
 
     protected Logger logger = LoggerFactory.getLogger(getClass());
 
-    private PrefsBean prefsBean;
     private final IpAddressProvider ipAddressProvider = new IpAddressProvider();
-    private final KeyFingerprintProvider keyFingerprintProvider = new KeyFingerprintProvider();
+
     private ServersRunningBean serversRunning;
     private long timestampOfLastEvent = 0;
 
@@ -105,10 +104,17 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
 
     private boolean onStartOngoing = false;
 
-    private String chosenIp;
+    SharedViewModel vm;
 
     protected int getLayoutId() {
         return R.layout.main;
+    }
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        vm = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     }
 
     /**
@@ -122,6 +128,8 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
 
         logger.debug("onCreateView()");
 
+        vm.onShowKeyFingerprints().observe(getViewLifecycleOwner(),
+                                           aVoid -> showKeyFingerprints());
         // layout
         View view = inflater.inflate(getLayoutId(), container, false);
 
@@ -130,7 +138,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         try (ExecutorService executorService = Executors.newSingleThreadExecutor()) {
             executorService.execute(() -> {
                 logger.trace("CalcPubkeyFinterprintsTask()");
-                keyFingerprintProvider.calcPubkeyFingerprints(fragment.getContext());
+                vm.getKeyFingerprintProvider().calcPubkeyFingerprints(fragment.getContext());
                 view.post(fragment::showKeyFingerprints);
             });
         }
@@ -153,11 +161,15 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         SharedPreferences prefs = LoadPrefsUtil.getPrefs(getContext());
         Boolean startOnOpen = LoadPrefsUtil.startOnOpen(prefs);
         if (startOnOpen) {
-            keyFingerprintProvider.calcPubkeyFingerprints(getContext()); // see GH issue #204
-            ServicesStartStopUtil.startServers(this);
+            vm.getKeyFingerprintProvider().calcPubkeyFingerprints(getContext()); // see GH issue #204
+            ServicesStartStopUtil.startServers(getContext(),
+                                               requireActivity().getSupportFragmentManager(),
+                                               vm.getChosenIp(),
+                                               vm.getKeyFingerprintProvider(),
+                                               vm.getPrefsBean());
         }
 
-        // init views (laoding & client action texts)
+        // init views (loading & client action texts)
         addressesLoading = view.findViewById(R.id.addressesLoading);
         clientActionView1 = view.findViewById(R.id.clientActionsLine1);
         clientActionView2 = view.findViewById(R.id.clientActionsLine2);
@@ -188,7 +200,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         logger.debug("onStart()");
         onStartOngoing = true;
 
-        loadPrefs();
+        vm.loadPrefs(getContext(), logger);
         showLogindata();
 
         // init storage type radio
@@ -197,7 +209,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
             return;
         }
         ((RadioGroup) view.findViewById(R.id.radioGroupStorage)).setOnCheckedChangeListener(this);
-        switch (prefsBean.getStorageType()) {
+        switch (vm.getPrefsBean().getStorageType()) {
             case PLAIN:
                 ((RadioButton) view.findViewById(R.id.radioStoragePlain)).setChecked(true);
                 break;
@@ -206,15 +218,15 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
                 break;
             case SAF:
                 ((RadioButton) view.findViewById(R.id.radioStorageSaf)).setChecked(true);
-                showSafUrl(prefsBean.getSafUrl());
+                showSafUrl(vm.getPrefsBean().getSafUrl());
                 break;
             case RO_SAF:
                 ((RadioButton) view.findViewById(R.id.radioStorageRoSaf)).setChecked(true);
-                showSafUrl(prefsBean.getSafUrl());
+                showSafUrl(vm.getPrefsBean().getSafUrl());
                 break;
             case VIRTUAL:
                 ((RadioButton) view.findViewById(R.id.radioStorageVirtual)).setChecked(true);
-                showSafUrl(prefsBean.getSafUrl());
+                showSafUrl(vm.getPrefsBean().getSafUrl());
                 break;
         }
 
@@ -245,8 +257,8 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         }
         try (ExecutorService executorService = Executors.newSingleThreadExecutor()) {
             executorService.execute(() -> {
-                if (!ipAddressProvider.isIpAvail(prefsBean.getBindIp())) {
-                    String msg = "IP " + prefsBean.getBindIp() +
+                if (!ipAddressProvider.isIpAvail(vm.getPrefsBean().getBindIp())) {
+                    String msg = "IP " + vm.getPrefsBean().getBindIp() +
                             " is currently not assigned to an interface. May lead to a crash.";
                     view.post(() ->
                         Toast.makeText(getContext(), msg, Toast.LENGTH_LONG).show()
@@ -322,7 +334,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         }
 
         if (storageType == StorageType.PLAIN || storageType == StorageType.ROOT) {
-            loadPrefs();
+            vm.loadPrefs(getContext(), logger);
             checkSafAccess();
         }
     }
@@ -347,7 +359,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
 
                 // release old permissions
                 FragmentActivity activity = requireActivity();
-                String oldUrl = prefsBean.getSafUrl();
+                String oldUrl = vm.getPrefsBean().getSafUrl();
                 if (!StringUtils.isBlank(oldUrl)) {
                     try {
                         activity.getContentResolver()
@@ -376,7 +388,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
                 showSafUrl(uriStr);
 
                 // update prefs
-                loadPrefs();
+                vm.loadPrefs(getContext(), logger);
 
                 // note: onResume() is about to be called
             }
@@ -390,14 +402,14 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
             return;
         }
         RadioButton safRadio = view.findViewById(R.id.radioStorageSaf);
-        if (prefsBean.getStorageType() == StorageType.SAF
-                || prefsBean.getStorageType() == StorageType.RO_SAF) {
+        if (vm.getPrefsBean().getStorageType() == StorageType.SAF
+                || vm.getPrefsBean().getStorageType() == StorageType.RO_SAF) {
             // let's see if the OS has persisted something for us
             List<UriPermission> persistedUriPermissions =
                     requireActivity().getContentResolver().getPersistedUriPermissions();
             for (UriPermission uriPerm : persistedUriPermissions) {
                 logger.debug("persisted uri perm: '{}', pref uri: '{}'",
-                        uriPerm.getUri(), prefsBean.getSafUrl());
+                        uriPerm.getUri(), vm.getPrefsBean().getSafUrl());
             }
             if (persistedUriPermissions.isEmpty()) {
                 logger.debug("no persisted uri perm");
@@ -405,7 +417,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
 
             Cursor cursor = null;
             try {
-                String url = prefsBean.getSafUrl();
+                String url = vm.getPrefsBean().getSafUrl();
                 Uri uri = Uri.parse(url);
                 cursor = requireActivity().getContentResolver().query(
                         uri,
@@ -483,8 +495,8 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         if (chooseBindIp) {
             radioGroup = new RadioGroup(this.getContext());
         } else {
-            // reset chosenIp, if user has diabled the preference again
-            this.chosenIp = null;
+            // reset chosenIp, if user has disabled the preference again
+            vm.setChosenIp(null);
         }
         radioGroupHolder[0] = radioGroup;
 
@@ -503,11 +515,11 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
                     radio.setText(ipAddressBean.getDisplayName());
                     radio.setId(idx);
                     radioButtonIdToIpaddr.put(idx, ipAddressBean.getIpAddress());
-                    if (this.chosenIp != null) {
-                        if (ipAddressBean.getIpAddress().equals(this.chosenIp)) {
+                    if (vm.getChosenIp() != null) {
+                        if (ipAddressBean.getIpAddress().equals(vm.getChosenIp())) {
                             radio.setChecked(true);
                         }
-                    } else if (ipAddressBean.getIpAddress().equals(prefsBean.getBindIp())) {
+                    } else if (ipAddressBean.getIpAddress().equals(vm.getPrefsBean().getBindIp())) {
                         radio.setChecked(true);
                     }
                     idx = idx + 1;
@@ -522,10 +534,8 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
 
             if (chooseBindIp) {
                 container.addView(radioGroupHolder[0]);
-
-                PftpdFragment fragment = this;
                 radioGroupHolder[0].setOnCheckedChangeListener((group, checkedId) ->
-                        fragment.chosenIp = radioButtonIdToIpaddr.get(checkedId)
+                        vm.setChosenIp(radioButtonIdToIpaddr.get(checkedId))
                 );
             }
         });
@@ -541,26 +551,26 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         }
         if (isLeftToRight) {
             ((TextView) view.findViewById(R.id.ftpTextView))
-                    .setText("ftp / " + prefsBean.getPortStr() + " / " +
+                    .setText("ftp / " + vm.getPrefsBean().getPortStr() + " / " +
                             getText(serversRunning.ftp
                                     ? R.string.serverStarted
                                     : R.string.serverStopped));
 
             ((TextView) view.findViewById(R.id.sftpTextView))
-                    .setText("sftp / " + prefsBean.getSecurePortStr() + " / " +
+                    .setText("sftp / " + vm.getPrefsBean().getSecurePortStr() + " / " +
                             getText(serversRunning.ssh
                                     ? R.string.serverStarted
                                     : R.string.serverStopped));
         } else {
             ((TextView) view.findViewById(R.id.ftpTextView))
-                    .setText(prefsBean.getPortStr() + " / " +
+                    .setText(vm.getPrefsBean().getPortStr() + " / " +
                             getText(serversRunning.ftp
                                     ? R.string.serverStarted
                                     : R.string.serverStopped)
                             + " / " + "ftp");
 
             ((TextView) view.findViewById(R.id.sftpTextView))
-                    .setText(prefsBean.getSecurePortStr() + " / " +
+                    .setText(vm.getPrefsBean().getSecurePortStr() + " / " +
                             getText(serversRunning.ssh
                                     ? R.string.serverStarted
                                     : R.string.serverStopped)
@@ -575,17 +585,17 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         }
 
         TextView usernameView = view.findViewById(R.id.usernameTextView);
-        usernameView.setText(getString(R.string.usernameLabel, prefsBean.getUserName()));
+        usernameView.setText(getString(R.string.usernameLabel, vm.getPrefsBean().getUserName()));
 
         TextView anonymousView = view.findViewById(R.id.anonymousLoginTextView);
-        anonymousView.setText(getString(R.string.isAnonymous, prefsBean.isAnonymousLogin()));
+        anonymousView.setText(getString(R.string.isAnonymous, vm.getPrefsBean().isAnonymousLogin()));
 
         TextView passwordPresentView = view.findViewById(R.id.passwordPresentTextView);
         passwordPresentView.setText(getString(R.string.passwordPresent,
-                StringUtils.isNotEmpty(prefsBean.getPassword())));
+                StringUtils.isNotEmpty(vm.getPrefsBean().getPassword())));
 
         TextView pubKeyAuthView = view.findViewById(R.id.pubKeyAuthTextView);
-        pubKeyAuthView.setText(getString(R.string.pubKeyAuth, prefsBean.isPubKeyAuth()));
+        pubKeyAuthView.setText(getString(R.string.pubKeyAuth, vm.getPrefsBean().isPubKeyAuth()));
 
         displayNormalStorageAccess();
         displayFullStorageAccess();
@@ -734,7 +744,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
             return;
         }
         // find algo to show
-        HostKeyAlgorithm chosenAlgo = keyFingerprintProvider.findPreferredHostKeyAlog(this.getContext());
+        HostKeyAlgorithm chosenAlgo = vm.getKeyFingerprintProvider().findPreferredHostKeyAlog(this.getContext());
 
         // show info about chosen algo and it's key
         ((TextView) view.findViewById(R.id.keyFingerprintMd5Label))
@@ -744,7 +754,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         ((TextView) view.findViewById(R.id.keyFingerprintSha256Label))
                 .setText("SHA256 (" + chosenAlgo.getDisplayName() + ")");
 
-        KeyFingerprintBean keyFingerprintBean = keyFingerprintProvider.getFingerprints().get(chosenAlgo);
+        KeyFingerprintBean keyFingerprintBean = vm.getKeyFingerprintProvider().getFingerprints().get(chosenAlgo);
 
         if (keyFingerprintBean != null) {
             ((TextView) view.findViewById(R.id.keyFingerprintMd5TextView))
@@ -756,11 +766,10 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         }
 
         // create onRefreshListener
-        PftpdFragment pftpdFragment = this;
         View refreshButton = view.findViewById(R.id.keyFingerprintsLabel);
         refreshButton.setOnClickListener(v -> {
             logger.trace("refreshButton OnClickListener");
-            GenKeysAskDialogFragment askDiag = new GenKeysAskDialogFragment(pftpdFragment);
+            GenKeysAskDialogFragment askDiag = new GenKeysAskDialogFragment();
             askDiag.show(requireActivity().getSupportFragmentManager(), DIALOG_TAG);
         });
 
@@ -899,27 +908,8 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         }
     }
 
-    protected void loadPrefs() {
-        logger.debug("loadPrefs()");
-
-        SharedPreferences prefs = LoadPrefsUtil.getPrefs(getContext());
-        this.prefsBean = LoadPrefsUtil.loadPrefs(logger, prefs);
-    }
-
-    public PrefsBean getPrefsBean() {
-        return prefsBean;
-    }
-
-    public KeyFingerprintProvider getKeyFingerprintProvider() {
-        return keyFingerprintProvider;
-    }
-
     @Override
     public void recreateLogger() {
         this.logger = LoggerFactory.getLogger(getClass());
-    }
-
-    public String getChosenIp() {
-        return chosenIp;
     }
 }

--- a/primitiveFTPd/src/org/primftpd/ui/PftpdFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/PftpdFragment.java
@@ -781,7 +781,7 @@ public class PftpdFragment extends Fragment implements RecreateLogger, RadioGrou
         showAllKeysFingerprints.setText(spannable);
         showAllKeysFingerprints.setOnClickListener(v -> {
             TabLayout tabLayout = view.getRootView().findViewById(R.id.tabs);
-            TabLayout.Tab tab = tabLayout.getTabAt(MainTabsActivity.INDEX_FINGERPRINTS);
+            TabLayout.Tab tab = tabLayout.getTabAt(vm.getFingerprintsFragmentTabIndex());
             if (tab != null) {
                 tab.select();
             }

--- a/primitiveFTPd/src/org/primftpd/ui/PubKeyAuthKeysFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/PubKeyAuthKeysFragment.java
@@ -59,9 +59,6 @@ public class PubKeyAuthKeysFragment extends Fragment {
             });
         }
 
-        List<String> keys = vm.loadKeysForDisplay(getContext(), logger);
-        displayKeys(view, keys);
-
         return view;
     }
 
@@ -70,11 +67,14 @@ public class PubKeyAuthKeysFragment extends Fragment {
                               @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        vm.onDisplayKeys().observe(getViewLifecycleOwner(),
-                                   keys -> displayKeys(getView(), keys));
+        vm.onDisplayKeys().observe(getViewLifecycleOwner(), this::displayKeys);
+
+        List<String> keys = vm.loadKeysForDisplay(getContext(), logger);
+        displayKeys(keys);
     }
 
-    private void displayKeys(View view, List<String> keys) {
+    private void displayKeys(List<String> keys) {
+        final View view = getView();
         LinearLayout container = view.findViewById(R.id.pubkeyAuthKeysContainer);
         container.removeAllViews();
         for (String key : keys) {

--- a/primitiveFTPd/src/org/primftpd/ui/PubKeyAuthKeysFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/PubKeyAuthKeysFragment.java
@@ -19,23 +19,27 @@ import org.primftpd.util.ServicesStartStopUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.security.PublicKey;
-import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 
 public class PubKeyAuthKeysFragment extends Fragment {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
-    protected final boolean isLeanback;
 
-    public PubKeyAuthKeysFragment(boolean isLeanback) {
-        this.isLeanback = isLeanback;
+    private SharedViewModel vm;
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        vm = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     }
 
     @Override
@@ -46,52 +50,28 @@ public class PubKeyAuthKeysFragment extends Fragment {
         View view = inflater.inflate(R.layout.pubkey_auth_keys, container, false);
 
         FloatingActionButton addButton = view.findViewById(R.id.addPubkeyAuthKey);
-        if (isLeanback) {
+        if (vm.isLeanBack()) {
             addButton.setVisibility(View.GONE);
         } else {
             addButton.setOnClickListener(v -> {
-                AddPubkeyAuthKeyDialogFragment addDiag = new AddPubkeyAuthKeyDialogFragment(this);
+                AddPubkeyAuthKeyDialogFragment addDiag = new AddPubkeyAuthKeyDialogFragment();
                 addDiag.show(requireActivity().getSupportFragmentManager(), PftpdFragment.DIALOG_TAG);
             });
         }
 
-        List<String> keys = loadKeysForDisplay();
+        List<String> keys = vm.loadKeysForDisplay(getContext(), logger);
         displayKeys(view, keys);
 
         return view;
     }
 
-    private List<String> loadKeysForDisplay() {
-        String[] keyPaths = new java.lang.String[]{
-                Defaults.PUB_KEY_AUTH_KEY_PATH_OLDER,
-                Defaults.PUB_KEY_AUTH_KEY_PATH_OLD,
-                Defaults.pubKeyAuthKeyPath(getContext()),
-        };
+    @Override
+    public void onViewCreated(@NonNull final View view,
+                              @Nullable final Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
-        List<String> keys = new ArrayList<>();
-        for (String path : keyPaths) {
-            keys.addAll(loadKeysOfFile(path));
-        }
-        return keys;
-    }
-
-    private List<String> loadKeysOfFile(String path) {
-        List<String> keys = new ArrayList<>();
-        try {
-            try (FileReader filereader = new FileReader(path)) {
-                BufferedReader reader = new BufferedReader(filereader);
-                while (reader.ready()) {
-                    String line = reader.readLine();
-                    if (!line.startsWith("#") && !line.isEmpty()) {
-                        keys.add(line);
-                    }
-                }
-            }
-        } catch (IOException e) {
-            logger.info("could not load key of path '{}': {}, {}",
-                    path, e.getClass().getName(), e.getMessage());
-        }
-        return keys;
+        vm.onDisplayKeys().observe(getViewLifecycleOwner(),
+                                   keys -> displayKeys(getView(), keys));
     }
 
     private void displayKeys(View view, List<String> keys) {
@@ -109,44 +89,5 @@ public class PubKeyAuthKeysFragment extends Fragment {
             textView.setText(R.string.noKeysPresent);
             container.addView(textView);
         }
-    }
-
-    protected void addKeyToFile(CharSequence key) {
-        final String path = Defaults.pubKeyAuthKeyPath(getContext());
-        if (validateKey(key)) {
-            try {
-                try (FileWriter writer = new FileWriter(path, true)) {
-                    writer.append("\n");
-                    writer.append(key);
-                }
-
-                View view = getView();
-                if (view != null) {
-                    List<String> keys = loadKeysForDisplay();
-                    displayKeys(view, keys);
-                }
-
-                ServersRunningBean serversRunningBean = ServicesStartStopUtil.checkServicesRunning(
-                        requireContext());
-                if (serversRunningBean.atLeastOneRunning()) {
-                    Toast.makeText(getContext(), R.string.restartServer, Toast.LENGTH_SHORT).show();
-                }
-            } catch (IOException e) {
-                logger.info("could not store key in file '{}': {}, {}",
-                        path, e.getClass().getName(), e.getMessage());
-            }
-        } else {
-            Toast.makeText(getContext(), R.string.pubkeyInvalid, Toast.LENGTH_SHORT).show();
-        }
-    }
-
-    protected boolean validateKey(CharSequence key) {
-        PublicKey pubKey = null;
-        try {
-            pubKey = KeyParser.parseKeyLine(key.toString());
-        } catch (Exception e) {
-            // handled by having pubKey equal null
-        }
-        return pubKey != null;
     }
 }

--- a/primitiveFTPd/src/org/primftpd/ui/QrFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/QrFragment.java
@@ -84,6 +84,14 @@ public class QrFragment extends Fragment implements RecreateLogger {
     }
 
     @Override
+    public void onViewCreated(@NonNull final View view,
+                              @Nullable final Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        vm.onUpdateQrCode().observe(getViewLifecycleOwner(), aVoid -> drawIfChanged());
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
         draw(vm.getChosenIp());

--- a/primitiveFTPd/src/org/primftpd/ui/QrFragment.java
+++ b/primitiveFTPd/src/org/primftpd/ui/QrFragment.java
@@ -38,7 +38,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 
 public class QrFragment extends Fragment implements RecreateLogger {
 
@@ -51,12 +53,15 @@ public class QrFragment extends Fragment implements RecreateLogger {
     private TextView fallbackTextView;
     private ProgressBar qrLoading;
 
-    private String lastChosenIp = null;
+    private String lastChosenIp;
 
-    final private PftpdFragment pftpdFragment;
+    private SharedViewModel vm;
 
-    public QrFragment(PftpdFragment pftpdFragment) {
-        this.pftpdFragment = pftpdFragment;
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        vm = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     }
 
     @Override
@@ -81,11 +86,11 @@ public class QrFragment extends Fragment implements RecreateLogger {
     @Override
     public void onResume() {
         super.onResume();
-        draw(pftpdFragment.getChosenIp());
+        draw(vm.getChosenIp());
     }
 
     public void drawIfChanged() {
-        String chosenIp = pftpdFragment.getChosenIp();
+        final String chosenIp = vm.getChosenIp();
         if (!Objects.equals(lastChosenIp, chosenIp)) {
             logger.debug("redraw needed");
             draw(chosenIp);
@@ -117,9 +122,9 @@ public class QrFragment extends Fragment implements RecreateLogger {
                 false,
                 isLeftToRight);
 
-        SharedPreferences prefs = LoadPrefsUtil.getPrefs(getContext());
-        PrefsBean prefsBean = LoadPrefsUtil.loadPrefs(logger, prefs);
+        PrefsBean prefsBean = vm.getPrefsBean(getContext(), logger);
 
+        SharedPreferences prefs = LoadPrefsUtil.getPrefs(getContext());
         Boolean showIpv4 = LoadPrefsUtil.showIpv4InNotification(prefs);
         Boolean showIpv6 = LoadPrefsUtil.showIpv6InNotification(prefs);
 

--- a/primitiveFTPd/src/org/primftpd/ui/SharedViewModel.java
+++ b/primitiveFTPd/src/org/primftpd/ui/SharedViewModel.java
@@ -42,11 +42,16 @@ public class SharedViewModel
     private PrefsBean prefsBean;
 
     private final MutableLiveData<Void> showKeyFingerprints = new MutableLiveData<>();
+    private final MutableLiveData<Void> updateQrCode = new MutableLiveData<>();
 
     private final MutableLiveData<List<String>> displayKeys = new MutableLiveData<>();
 
     MutableLiveData<Void> onShowKeyFingerprints() {
         return showKeyFingerprints;
+    }
+
+    MutableLiveData<Void> onUpdateQrCode() {
+        return updateQrCode;
     }
 
     MutableLiveData<List<String>> onDisplayKeys() {
@@ -113,6 +118,9 @@ public class SharedViewModel
         return keyFingerprintProvider;
     }
 
+    void updateQrCode() {
+        updateQrCode.setValue(null);
+    }
 
     List<String> loadKeysForDisplay(Context context,
                                     Logger logger) {

--- a/primitiveFTPd/src/org/primftpd/ui/SharedViewModel.java
+++ b/primitiveFTPd/src/org/primftpd/ui/SharedViewModel.java
@@ -41,6 +41,8 @@ public class SharedViewModel
     private String chosenIp;
     private PrefsBean prefsBean;
 
+    private int fingerprintsFragmentTabIndex;
+
     private final MutableLiveData<Void> showKeyFingerprints = new MutableLiveData<>();
     private final MutableLiveData<Void> updateQrCode = new MutableLiveData<>();
 
@@ -112,6 +114,14 @@ public class SharedViewModel
 
     void setChosenIp(final String chosenIp) {
         this.chosenIp = chosenIp;
+    }
+
+    public int getFingerprintsFragmentTabIndex() {
+        return fingerprintsFragmentTabIndex;
+    }
+
+    public void setFingerprintsFragmentTabIndex(final int fingerprintsFragmentTabIndex) {
+        this.fingerprintsFragmentTabIndex = fingerprintsFragmentTabIndex;
     }
 
     KeyFingerprintProvider getKeyFingerprintProvider() {

--- a/primitiveFTPd/src/org/primftpd/ui/SharedViewModel.java
+++ b/primitiveFTPd/src/org/primftpd/ui/SharedViewModel.java
@@ -1,0 +1,200 @@
+package org.primftpd.ui;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.primftpd.R;
+import org.primftpd.pojo.KeyParser;
+import org.primftpd.prefs.LoadPrefsUtil;
+import org.primftpd.prefs.PrefsBean;
+import org.primftpd.util.Defaults;
+import org.primftpd.util.KeyFingerprintProvider;
+import org.primftpd.util.ServersRunningBean;
+import org.primftpd.util.ServicesStartStopUtil;
+import org.slf4j.Logger;
+
+/**
+ * This is not the best code I wrote.
+ * But it's a meant as a quick fix to GitHub #437 by simply moving existing code
+ * to this ViewModel.
+ */
+public class SharedViewModel
+        extends ViewModel {
+
+    private final KeyFingerprintProvider keyFingerprintProvider = new KeyFingerprintProvider();
+    private boolean leanBack;
+    private String chosenIp;
+    private PrefsBean prefsBean;
+
+    private final MutableLiveData<Void> showKeyFingerprints = new MutableLiveData<>();
+
+    private final MutableLiveData<List<String>> displayKeys = new MutableLiveData<>();
+
+    MutableLiveData<Void> onShowKeyFingerprints() {
+        return showKeyFingerprints;
+    }
+
+    MutableLiveData<List<String>> onDisplayKeys() {
+        return displayKeys;
+    }
+
+    void updateKeyFingerprints() {
+        showKeyFingerprints.setValue(null);
+    }
+
+    void init(Context context,
+              Logger logger) {
+        loadPrefs(context, logger);
+    }
+
+    void loadPrefs(Context context,
+                   Logger logger) {
+        logger.debug("loadPrefs()");
+
+        SharedPreferences prefs = LoadPrefsUtil.getPrefs(context);
+        this.prefsBean = LoadPrefsUtil.loadPrefs(logger, prefs);
+    }
+
+    /**
+     * Reload the preference bean.
+     *
+     * @param context
+     * @param logger
+     *
+     * @return bean
+     */
+    public PrefsBean getPrefsBean(Context context,
+                                  Logger logger) {
+        loadPrefs(context, logger);
+        return prefsBean;
+    }
+
+    /**
+     * Load the previously loaded bean.
+     *
+     * @return bean
+     */
+    public PrefsBean getPrefsBean() {
+        return prefsBean;
+    }
+
+    boolean isLeanBack() {
+        return leanBack;
+    }
+
+    void setLeanBack(final boolean leanBack) {
+        this.leanBack = leanBack;
+    }
+
+    String getChosenIp() {
+        return chosenIp;
+    }
+
+    void setChosenIp(final String chosenIp) {
+        this.chosenIp = chosenIp;
+    }
+
+    KeyFingerprintProvider getKeyFingerprintProvider() {
+        return keyFingerprintProvider;
+    }
+
+
+    List<String> loadKeysForDisplay(Context context,
+                                    Logger logger) {
+        String[] keyPaths = {
+                Defaults.PUB_KEY_AUTH_KEY_PATH_OLDER,
+                Defaults.PUB_KEY_AUTH_KEY_PATH_OLD,
+                Defaults.pubKeyAuthKeyPath(context),
+        };
+
+        List<String> keys = new ArrayList<>();
+        for (String path : keyPaths) {
+            keys.addAll(loadKeysOfFile(path, logger));
+        }
+        return keys;
+    }
+
+    private List<String> loadKeysOfFile(String path, Logger logger) {
+        List<String> keys = new ArrayList<>();
+        try {
+            try (FileReader filereader = new FileReader(path)) {
+                BufferedReader reader = new BufferedReader(filereader);
+                while (reader.ready()) {
+                    String line = reader.readLine();
+                    if (!line.startsWith("#") && !line.isEmpty()) {
+                        keys.add(line);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            logger.info("could not load key of path '{}': {}, {}",
+                        path, e.getClass().getName(), e.getMessage());
+        }
+        return keys;
+    }
+
+    private boolean validateKey(@NonNull CharSequence key) {
+        PublicKey pubKey = null;
+        try {
+            pubKey = KeyParser.parseKeyLine(key.toString());
+        } catch (Exception e) {
+            // handled by having pubKey equal null
+        }
+        return pubKey != null;
+    }
+
+    /**
+     * Add the given key to the {@code authorized_keys}.
+     *
+     * @param context
+     * @param key
+     * @param logger
+     *
+     * @return a message to show to the user, of {@code null} for none.
+     */
+    @Nullable
+    public String addKeyToFile(@NonNull Context context,
+                               @NonNull CharSequence key,
+                               @NonNull Logger logger) {
+        final String path = Defaults.pubKeyAuthKeyPath(context);
+        if (validateKey(key)) {
+            try {
+                try (FileWriter writer = new FileWriter(path, true)) {
+                    writer.append("\n");
+                    writer.append(key);
+                }
+
+                List<String> keys = loadKeysForDisplay(context, logger);
+                displayKeys.setValue(keys);
+
+                ServersRunningBean serversRunningBean =
+                        ServicesStartStopUtil.checkServicesRunning(context);
+                if (serversRunningBean.atLeastOneRunning()) {
+                    return context.getString(R.string.restartServer);
+                }
+            } catch (IOException e) {
+                logger.info("could not store key in file '{}': {}, {}",
+                            path, e.getClass().getName(), e.getMessage());
+            }
+        } else {
+            return context.getString(R.string.pubkeyInvalid);
+        }
+
+        return null;
+    }
+}

--- a/primitiveFTPd/src/org/primftpd/util/ServicesStartStopUtil.java
+++ b/primitiveFTPd/src/org/primftpd/util/ServicesStartStopUtil.java
@@ -12,6 +12,10 @@ import android.os.Bundle;
 import android.widget.RemoteViews;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentManager;
+
 import org.primftpd.prefs.PrefsBean;
 import org.primftpd.R;
 import org.primftpd.share.QuickShareBean;
@@ -42,51 +46,43 @@ public class ServicesStartStopUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ServicesStartStopUtil.class);
 
-    public static void startServers(PftpdFragment fragment) {
-        startServers(null, null, null, fragment, null);
+    public static void startServers(@NonNull Context context,
+                                    @Nullable FragmentManager fragmentManager,
+                                    @Nullable String chosenIp,
+                                    @Nullable KeyFingerprintProvider keyFingerprintProvider,
+                                    @Nullable PrefsBean prefsBean) {
+        startServers(context, prefsBean, keyFingerprintProvider, fragmentManager, null, chosenIp);
     }
+
     public static void startServers(Context context) {
-        startServers(context, null, null, null, null);
+        startServers(context, null, null, null, null, null);
     }
 
     public static void startServers(Context context, QuickShareBean quickShareBean) {
-        startServers(context, null, null, null, quickShareBean);
+        startServers(context, null, null, null, quickShareBean, null);
     }
 
     private static void startServers(
             Context context,
             PrefsBean prefsBean,
             KeyFingerprintProvider keyFingerprintProvider,
-            PftpdFragment fragment,
-            QuickShareBean quickShareBean) {
+            FragmentManager fragmentManager,
+            QuickShareBean quickShareBean,
+            String chosenIp) {
         LOGGER.trace("startServers()");
 
-        if (context == null && fragment != null) {
-            context = fragment.getContext();
-        }
         if (context == null) {
             LOGGER.error("context is null, not starting server");
             return;
         }
 
         if (prefsBean == null) {
-            if (fragment != null) {
-                prefsBean = fragment.getPrefsBean();
-            }
-            if (prefsBean == null) {
-                SharedPreferences prefs = LoadPrefsUtil.getPrefs(context);
-                prefsBean = LoadPrefsUtil.loadPrefs(LOGGER, prefs);
-            }
+            SharedPreferences prefs = LoadPrefsUtil.getPrefs(context);
+            prefsBean = LoadPrefsUtil.loadPrefs(LOGGER, prefs);
         }
         if (keyFingerprintProvider == null) {
-            if (fragment != null) {
-                keyFingerprintProvider = fragment.getKeyFingerprintProvider();
-            }
-            if (keyFingerprintProvider == null) {
-                keyFingerprintProvider = new KeyFingerprintProvider();
-            }
+            keyFingerprintProvider = new KeyFingerprintProvider();
         }
-        String chosenIp = fragment != null ? fragment.getChosenIp() : null;
 
         if (!isPasswordOk(prefsBean)) {
             Toast.makeText(
@@ -94,7 +90,7 @@ public class ServicesStartStopUtil {
                 R.string.haveToSetAuthMechanism,
                 Toast.LENGTH_LONG).show();
 
-            if (fragment == null) {
+            if (fragmentManager == null) {
                 // Launch the main activity so that the user may set their password.
                 Intent activityIntent = new Intent(context, MainTabsActivity.class);
                 activityIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -104,12 +100,12 @@ public class ServicesStartStopUtil {
             boolean continueServerStart = true;
             if (prefsBean.getServerToStart().startSftp()) {
                 boolean keyPresent = true;
-                if (fragment != null) {
+                if (fragmentManager != null) {
                     keyPresent = isKeyPresent(keyFingerprintProvider, context);
                     if (!keyPresent) {
                         // cannot start sftp server when key is not present
                         // ask user to generate it
-                        showGenKeyDialog(fragment);
+                        showGenKeyDialog(fragmentManager);
                         continueServerStart = false;
                     }
                 }
@@ -171,13 +167,13 @@ public class ServicesStartStopUtil {
         }
     }
 
-    private static void showGenKeyDialog(PftpdFragment fragment) {
+    private static void showGenKeyDialog(FragmentManager fragmentManager) {
         LOGGER.trace("showGenKeyDialog()");
-        GenKeysAskDialogFragment askDiag = new GenKeysAskDialogFragment(fragment);
+        GenKeysAskDialogFragment askDiag = new GenKeysAskDialogFragment();
         Bundle diagArgs = new Bundle();
         diagArgs.putBoolean(GenKeysAskDialogFragment.KEY_START_SERVER, true);
         askDiag.setArguments(diagArgs);
-        askDiag.show(fragment.requireActivity().getSupportFragmentManager(), PftpdFragment.DIALOG_TAG);
+        askDiag.show(fragmentManager, PftpdFragment.DIALOG_TAG);
     }
 
     private static void startServerByIntent(Intent intent, Context context) {


### PR DESCRIPTION
- introduced SharedViewModel
- moved the simple attributes for the `leanback` flag and the `chosenIp`
  This solved the issues with the fragments mentioned in the bug report.
- subsequently found more Fragment constructors which took parameters.
- Expanded the use of the ViewModel to those as well, and introduced 2 LiveData's to make the (now removed) foreign fragments ware of changes.

Sorry for the short notes... please ask if anything is not clear.

SIMPLE tests showed that device rotation no longer causes the app to crash.
But further tests MUST be done obviously to make sure all scenarios are covered.